### PR TITLE
Global channel update

### DIFF
--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -177,9 +177,6 @@ def addAllVariables(dfw, syst_name, isData, trigger_class, lepton_legs, isSignal
         hltBranches = dfw.Apply(trigger_class.ApplyTriggers, lepton_legs, isData, applyTriggerFilter )
         dfw.colToSave.extend(hltBranches)
 
-    for leg_name in lepton_legs:
-        dfw.Redefine(f"{leg_name}_legType", f"static_cast<int>({leg_name}_legType)")
-
     dfw.DefineAndAppend("channelId","static_cast<int>(HwwCandidate.channel())")
     channel_to_select = " || ".join(f"HwwCandidate.channel()==Channel::{ch}" for ch in channels)#global_params["channelSelection"])
     dfw.Filter(channel_to_select, "select channels")

--- a/config/Datacards/x_hh_bbww_run3.yaml
+++ b/config/Datacards/x_hh_bbww_run3.yaml
@@ -25,7 +25,14 @@ processes:
     hist_name: GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_${MX}
     param_values: [ 250, 260, 270, 280, 300, 350, 450, 550, 600, 650, 700, 800 ]
     is_signal: true
-    scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02 + 2 * 2.619E-02 * 3 * 3.3658e-02 * 0.2)
+    # 125.0 H->bb BR 5.824e-01 https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+    # 125.0 H->WW BR 2.137e-01 
+    # 125.0 H->ZZ BR 2.619e-02
+    # W->lv 10.86e-02 https://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
+    # W->hadrons BR 67.41e-02 (1 - 3 * 10.86e-02)
+    # Z->ll 3.3658e-02
+    # Z->invisible 20e-02
+    scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02 + 2 * 2.619E-02 * 3 * 3.3658e-02 * 20e-02)
   - TT
   - DY
   - VV

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -36,8 +36,8 @@ channels_to_consider:
   - muMu
 
 channelDefinition:
-  e: 10 #Second lepton doesn't exist
-  mu: 20
+  e: 1 #Second lepton doesn't exist
+  mu: 2
   eE: 11
   eMu: 12
   muMu: 22
@@ -48,21 +48,38 @@ categories:
   - baseline
   - res1b
   - res2b
+  - res1b_Zveto_MbbSR
+  - res2b_Zveto_MbbSR
 
 region_default: SR
+
+SignRegions:
+  - OS_Iso
+  - SS_Iso
+  - OS_AntiIso
+  - SS_AntiIso
+  # - Zpeak_0b
+  # - Zpeak_1b
+  # - Zpeak_2b
+  # - ZVeto_0b
+  # - ZVeto_1b
+  # - ZVeto_2b
+  # - TTbar_CR
+
 
 QCDRegions:
   - OS_Iso
   - SS_Iso
   - OS_AntiIso
   - SS_AntiIso
-  - Zpeak_0b
-  - Zpeak_1b
-  - Zpeak_2b
-  - ZVeto_0b
-  - ZVeto_1b
-  - ZVeto_2b
-  - TTbar_CR
+  # - Zpeak_0b
+  # - Zpeak_1b
+  # - Zpeak_2b
+  # - ZVeto_0b
+  # - ZVeto_1b
+  # - ZVeto_2b
+  # - TTbar_CR
+
 boosted_categories: []
 
 


### PR DESCRIPTION
Update channelDefinition to match channelId for a change from many months ago (fixes single lepton histograms from being empty to being full)

Comment out the different DY control regions from the default running (only runs QCDRegions for non-experts (not Muhammad) )

Copied QCDRegions to also be called SignRegions until Valeria figures out what the future of this config will be