### PR TITLE
Add Offline Legs and trigger.yaml updates

### DIFF
--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -177,9 +177,6 @@ def addAllVariables(dfw, syst_name, isData, trigger_class, lepton_legs, isSignal
         hltBranches = dfw.Apply(trigger_class.ApplyTriggers, lepton_legs, isData, applyTriggerFilter )
         dfw.colToSave.extend(hltBranches)
 
-    for leg_name in lepton_legs:
-        dfw.Redefine(f"{leg_name}_legType", f"static_cast<int>({leg_name}_legType)")
-
     dfw.DefineAndAppend("channelId","static_cast<int>(HwwCandidate.channel())")
     channel_to_select = " || ".join(f"HwwCandidate.channel()==Channel::{ch}" for ch in channels)#global_params["channelSelection"])
     dfw.Filter(channel_to_select, "select channels")

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -5,6 +5,7 @@ from Corrections.Corrections import Corrections
 loadTF = False
 loadHHBtag = False
 lepton_legs = [ "lep1", "lep2" ]
+offline_legs = [ "lep1", "lep2"]
 
 
 Muon_int_observables = ["Muon_tightId","Muon_highPtId","Muon_pfIsoId"]
@@ -72,7 +73,8 @@ FatJetObservablesMC = ["hadronFlavour","partonFlavour"]
 SubJetObservables = ["btagDeepB", "eta", "mass", "phi", "pt", "rawFactor"]
 SubJetObservablesMC = ["hadronFlavour","partonFlavour"]
 
-defaultColToSave = ["entryIndex","luminosityBlock", "run","event", "sample_type", "sample_name", "period", "X_mass", "X_spin", "isData","PuppiMET_pt", "PuppiMET_phi", "nJet","DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi","DeepMETResponseTune_pt", "DeepMETResponseTune_phi","PV_npvs"]
+# defaultColToSave = ["entryIndex","luminosityBlock", "run","event", "sample_type", "sample_name", "period", "X_mass", "X_spin", "isData","PuppiMET_pt", "PuppiMET_phi", "nJet","DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi","DeepMETResponseTune_pt", "DeepMETResponseTune_phi","PV_npvs"]
+defaultColToSave = ["FullEventId","luminosityBlock", "run","event", "sample_type", "period", "X_mass", "X_spin", "isData","PuppiMET_pt", "PuppiMET_phi", "nJet","DeepMETResolutionTune_pt", "DeepMETResolutionTune_phi","DeepMETResponseTune_pt", "DeepMETResponseTune_phi","PV_npvs"]
 
 def getDefaultColumnsToSave(isData):
     colToSave = defaultColToSave.copy()

--- a/config/Datacards/x_hh_bbww_run3.yaml
+++ b/config/Datacards/x_hh_bbww_run3.yaml
@@ -25,7 +25,14 @@ processes:
     hist_name: GluGlutoRadiontoHHto2B2Vto2B2L2Nu_M_${MX}
     param_values: [ 250, 260, 270, 280, 300, 350, 450, 550, 600, 650, 700, 800 ]
     is_signal: true
-    scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02 + 2 * 2.619E-02 * 3 * 3.3658e-02 * 0.2)
+    # 125.0 H->bb BR 5.824e-01 https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+    # 125.0 H->WW BR 2.137e-01 
+    # 125.0 H->ZZ BR 2.619e-02
+    # W->lv 10.86e-02 https://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
+    # W->hadrons BR 67.41e-02 (1 - 3 * 10.86e-02)
+    # Z->ll 3.3658e-02
+    # Z->invisible 20e-02
+    scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02 + 2 * 2.619E-02 * 3 * 3.3658e-02 * 20e-02)
   - TT
   - DY
   - VV

--- a/config/Run3_2022/triggers.yaml
+++ b/config/Run3_2022/triggers.yaml
@@ -11,6 +11,10 @@ singleIsoMu:
       online_obj:
         cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
       doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2022_Summer22EE": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+      }
 
 singleIsoMuHT:
   channels:
@@ -51,6 +55,10 @@ singleEleWpTight:
       online_obj:
         cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0
       doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "Electron-HLT-SF",
+        "2022_Summer22EE": "Electron-HLT-SF"
+      }
 
 diElec:
   channels:

--- a/config/Run3_2022EE/triggers.yaml
+++ b/config/Run3_2022EE/triggers.yaml
@@ -11,6 +11,10 @@ singleIsoMu:
       online_obj:
         cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
       doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2022_Summer22EE": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+      }
 
 singleIsoMuHT:
   channels:
@@ -25,6 +29,8 @@ singleIsoMuHT:
       online_obj:
         cut: TrigObj_id == 13 && (TrigObj_filterBits&32)!=0
       doMatching: False
+
+
 singleIsoEleHT:
   channels:
     - eE
@@ -38,6 +44,9 @@ singleIsoEleHT:
       online_obj:
         cut: TrigObj_id == 11 && (TrigObj_filterBits&32)!=0
       doMatching: False
+
+
+
 singleEleWpTight:
   channels:
     - eMu
@@ -51,6 +60,10 @@ singleEleWpTight:
       online_obj:
         cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0
       doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "Electron-HLT-SF",
+        "2022_Summer22EE": "Electron-HLT-SF"
+      }
 
 diElec:
   channels:

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -36,8 +36,8 @@ channels_to_consider:
   - muMu
 
 channelDefinition:
-  e: 10 #Second lepton doesn't exist
-  mu: 20
+  e: 1 #Second lepton doesn't exist
+  mu: 2
   eE: 11
   eMu: 12
   muMu: 22
@@ -48,21 +48,38 @@ categories:
   - baseline
   - res1b
   - res2b
+  - res1b_Zveto_MbbSR
+  - res2b_Zveto_MbbSR
 
 region_default: SR
+
+SignRegions:
+  - OS_Iso
+  - SS_Iso
+  - OS_AntiIso
+  - SS_AntiIso
+  # - Zpeak_0b
+  # - Zpeak_1b
+  # - Zpeak_2b
+  # - ZVeto_0b
+  # - ZVeto_1b
+  # - ZVeto_2b
+  # - TTbar_CR
+
 
 QCDRegions:
   - OS_Iso
   - SS_Iso
   - OS_AntiIso
   - SS_AntiIso
-  - Zpeak_0b
-  - Zpeak_1b
-  - Zpeak_2b
-  - ZVeto_0b
-  - ZVeto_1b
-  - ZVeto_2b
-  - TTbar_CR
+  # - Zpeak_0b
+  # - Zpeak_1b
+  # - Zpeak_2b
+  # - ZVeto_0b
+  # - ZVeto_1b
+  # - ZVeto_2b
+  # - TTbar_CR
+
 boosted_categories: []
 
 

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -7,7 +7,7 @@ signal_types:
   - GluGluToBulkGraviton
 corrections:
   - mu
-  - trg
+  - trgSF
   - ele
   - eleES
   - pu


### PR DESCRIPTION
It looks like bbtautau and FLAF are moving to have a single 'triggers.yaml' instead of separate ones for each year? This may be a future improvement for us too, but for now I just want it to run