### PR TITLE
HME split

### DIFF
--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -16,7 +16,7 @@ Electron_float_observables = ["Electron_pfRelIso03_all","Electron_miniPFRelIso_a
 Electron_observables = Electron_int_observables + Electron_float_observables
 JetObservables = ["PNetRegPtRawCorr", "PNetRegPtRawCorrNeutrino", "PNetRegPtRawRes", "rawFactor",
                   "btagDeepFlavB", "btagDeepFlavCvB", "btagDeepFlavCvL", "btagDeepFlavQG",
-                  "btagPNetB", "btagPNetCvB", "btagPNetCvL", "btagPNetCvNotB", "btagPNetQvG", "ptRes", "idbtagPNetB"] # 2024
+                  "btagPNetB", "btagPNetCvB", "btagPNetCvL", "btagPNetCvNotB", "btagPNetQvG", "ptRes", "idbtagPNetB", "area"] # 2024
 
 JetObservablesMC = ["hadronFlavour", "partonFlavour"]
 

--- a/Analysis/PayloadProducers.py
+++ b/Analysis/PayloadProducers.py
@@ -7,17 +7,21 @@ class HMEProducer:
     def run(self, dfw):
         if "ncentralJet" not in dfw.df.GetColumnNames():
             dfw.Define("ncentralJet", "return centralJet_pt.size();")
-        if self.cfg['channel'] == "DL":
+
+        ch = self.cfg['channel']
+        if ch == "DL":
             dfw.Define("has_necessary_inputs", "ncentralJet >= 2 && lep1_pt > 0.0 && lep2_pt > 0.0")
-        elif self.cfg['channel'] == "SL":
+        elif ch == "SL":
             dfw.Define("has_necessary_inputs", "ncentralJet >= 4 && lep1_pt > 0.0")
-        
-        dfw.df = GetHMEVariables(dfw.df, self.cfg['channel'])
+        else:
+            raise RuntimeError(f"Illegal channel in config: {ch}")
+
+        dfw.df = GetHMEVariables(dfw.df, ch)
         for col in self.cfg['columns']:
             if col != 'valid':
-                dfw.DefineAndAppend(f"HME_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
+                dfw.DefineAndAppend(f"HME_{ch}_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
         if 'valid' in self.cfg['columns']:
-            dfw.DefineAndAppend("HME_valid", "return HME_mass > 0.0;")
+            dfw.DefineAndAppend(f"HME_{ch}_valid", f"return HME_{ch}_mass > 0.0;")
         return dfw
 
 class DNNProducer:

--- a/Analysis/PayloadProducers.py
+++ b/Analysis/PayloadProducers.py
@@ -1,8 +1,9 @@
 from Studies.HME.new.hmeVariables import GetHMEVariables
 
 class HMEProducer:
-    def __init__(self, cfg):
+    def __init__(self, cfg, payload_name):
         self.cfg = cfg
+        self.payload_name = payload_name
 
     def run(self, dfw):
         if "ncentralJet" not in dfw.df.GetColumnNames():
@@ -19,9 +20,9 @@ class HMEProducer:
         dfw.df = GetHMEVariables(dfw.df, ch)
         for col in self.cfg['columns']:
             if col != 'valid':
-                dfw.DefineAndAppend(f"HME_{ch}_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
+                dfw.DefineAndAppend(f"{self.payload_name}_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
         if 'valid' in self.cfg['columns']:
-            dfw.DefineAndAppend(f"HME_{ch}_valid", f"return HME_{ch}_mass > 0.0;")
+            dfw.DefineAndAppend(f"{self.payload_name}_valid", f"return {self.payload_name}_mass > 0.0;")
         return dfw
 
 class DNNProducer:

--- a/Analysis/PayloadProducers.py
+++ b/Analysis/PayloadProducers.py
@@ -5,19 +5,24 @@ class HMEProducer:
         self.cfg = cfg
 
     def run(self, dfw):
+        channel_name = None
         if "ncentralJet" not in dfw.df.GetColumnNames():
             dfw.Define("ncentralJet", "return centralJet_pt.size();")
         if self.cfg['channel'] == "DL":
+            channel_name = 'DL'
             dfw.Define("has_necessary_inputs", "ncentralJet >= 2 && lep1_pt > 0.0 && lep2_pt > 0.0")
         elif self.cfg['channel'] == "SL":
+            channel_name = 'SL'
             dfw.Define("has_necessary_inputs", "ncentralJet >= 4 && lep1_pt > 0.0")
+        else:
+            raise RuntimeError(f'Passed illegal option to HMEProducer config: channel {self.cfg['channel']}')
         
         dfw.df = GetHMEVariables(dfw.df, self.cfg['channel'])
         for col in self.cfg['columns']:
             if col != 'valid':
-                dfw.DefineAndAppend(f"HME_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
+                dfw.DefineAndAppend(f"HME_{channel_name}_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
         if 'valid' in self.cfg['columns']:
-            dfw.DefineAndAppend("HME_valid", "return HME_mass > 0.0;")
+            dfw.DefineAndAppend(f"HME_{channel_name}_valid", "return HME_mass > 0.0;")
         return dfw
 
 class DNNProducer:

--- a/Analysis/PayloadProducers.py
+++ b/Analysis/PayloadProducers.py
@@ -5,24 +5,19 @@ class HMEProducer:
         self.cfg = cfg
 
     def run(self, dfw):
-        channel_name = None
         if "ncentralJet" not in dfw.df.GetColumnNames():
             dfw.Define("ncentralJet", "return centralJet_pt.size();")
         if self.cfg['channel'] == "DL":
-            channel_name = 'DL'
             dfw.Define("has_necessary_inputs", "ncentralJet >= 2 && lep1_pt > 0.0 && lep2_pt > 0.0")
         elif self.cfg['channel'] == "SL":
-            channel_name = 'SL'
             dfw.Define("has_necessary_inputs", "ncentralJet >= 4 && lep1_pt > 0.0")
-        else:
-            raise RuntimeError(f'Passed illegal option to HMEProducer config: channel {self.cfg['channel']}')
         
         dfw.df = GetHMEVariables(dfw.df, self.cfg['channel'])
         for col in self.cfg['columns']:
             if col != 'valid':
-                dfw.DefineAndAppend(f"HME_{channel_name}_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
+                dfw.DefineAndAppend(f"HME_{col}", f"return hme_output[static_cast<size_t>(HME::EstimOut::{col})];")
         if 'valid' in self.cfg['columns']:
-            dfw.DefineAndAppend(f"HME_{channel_name}_valid", "return HME_mass > 0.0;")
+            dfw.DefineAndAppend("HME_valid", "return HME_mass > 0.0;")
         return dfw
 
 class DNNProducer:

--- a/Studies/HME/new/hmeVariables.py
+++ b/Studies/HME/new/hmeVariables.py
@@ -28,9 +28,22 @@ def GetHMEVariables(df, channel):
     df = df.Define("met", """HME::LorentzVectorF_t res(PuppiMET_pt, 0.0, PuppiMET_phi, 0.0);    
                           return res;""")
 		  
+    df = df.Define("btags", """std::vector<Float_t> res;
+                           for (size_t i = 0; i < ncentralJet; ++i)
+                           {{
+                                res.emplace_back(centralJet_btagPNetB[i]);  
+                            }}
+                            return res;""")
+    df = df.Define("light_tags", """std::vector<Float_t> res;
+                           for (size_t i = 0; i < ncentralJet; ++i)
+                           {{
+                                res.emplace_back(centralJet_btagPNetQvG[i]);  
+                            }}
+                            return res;""")
+        
     df = df.Define("hme_output", f"""if (has_necessary_inputs)
                                     {{
-                                        auto const& hme = estimator->EstimateMass(jets, leptons, met, event, HME::Channel::{channel});
+                                        auto const& hme = estimator->EstimateMass(jets, leptons, met, btags, light_tags, event, HME::Channel::{channel});
                                         if (hme.has_value())
                                         {{
                                             return hme.value();

--- a/Studies/HME/new/include/Constants.hpp
+++ b/Studies/HME/new/include/Constants.hpp
@@ -48,7 +48,7 @@ namespace HME
     inline constexpr Float_t HIGGS_WIDTH = 0.004;
     inline constexpr Float_t TOL = 10e-7;
     inline constexpr int N_ATTEMPTS = 1;
-    inline constexpr int N_ITER = 10000;
+    inline constexpr int N_ITER = 1000;
     inline constexpr int CONTROL = 4;
 
     inline constexpr Float_t MAX_MASS = 4000.0;

--- a/Studies/HME/new/include/Constants.hpp
+++ b/Studies/HME/new/include/Constants.hpp
@@ -48,7 +48,7 @@ namespace HME
     inline constexpr Float_t HIGGS_WIDTH = 0.004;
     inline constexpr Float_t TOL = 10e-7;
     inline constexpr int N_ATTEMPTS = 1;
-    inline constexpr int N_ITER = 1000;
+    inline constexpr int N_ITER = 10000;
     inline constexpr int CONTROL = 4;
 
     inline constexpr Float_t MAX_MASS = 4000.0;
@@ -61,7 +61,8 @@ namespace HME
     inline constexpr unsigned Q16 = 16;
     inline constexpr unsigned Q84 = 84;
 
-    inline constexpr size_t NUM_BEST_BTAG = 2;
+    inline constexpr size_t NUM_BEST_BTAG = 3;
+    inline constexpr size_t NUM_BEST_QVG = 3;
 
     inline static const std::unordered_map<PDF1_sl, TString> pdf1d_sl_names = { { PDF1_sl::numet_pt, "pdf_numet_pt" },
                                                                                 { PDF1_sl::numet_dphi, "pdf_numet_dphi" },

--- a/Studies/HME/new/include/Constants.hpp
+++ b/Studies/HME/new/include/Constants.hpp
@@ -48,7 +48,7 @@ namespace HME
     inline constexpr Float_t HIGGS_WIDTH = 0.004;
     inline constexpr Float_t TOL = 10e-7;
     inline constexpr int N_ATTEMPTS = 1;
-    inline constexpr int N_ITER = 1000;
+    inline constexpr int N_ITER = 10000;
     inline constexpr int CONTROL = 4;
 
     inline constexpr Float_t MAX_MASS = 4000.0;

--- a/Studies/HME/new/include/Estimator.hpp
+++ b/Studies/HME/new/include/Estimator.hpp
@@ -11,7 +11,12 @@ namespace HME
     {
         public:
         Estimator(TString const& pdf_file_name_sl, TString const& pdf_file_name_dl);
-        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id, Channel ch);
+        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, 
+                                             VecLVF_t const& leptons, 
+                                             LorentzVectorF_t const& met, 
+                                             std::vector<Float_t> const& btags,
+                                             std::vector<Float_t> const& light_tags, 
+                                             ULong64_t evt_id, Channel ch);
 
         private:
         EstimatorSingleLep m_estimator_sl;
@@ -23,15 +28,20 @@ namespace HME
     ,   m_estimator_dl(pdf_file_name_dl)
     {}
 
-    OptArrF_t<ESTIM_OUT_SZ> Estimator::EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id, Channel ch)
+    OptArrF_t<ESTIM_OUT_SZ> Estimator::EstimateMass(VecLVF_t const& jets, 
+                                                    VecLVF_t const& leptons, 
+                                                    LorentzVectorF_t const& met, 
+                                                    std::vector<Float_t> const& btags,
+                                                    std::vector<Float_t> const& light_tags, 
+                                                    ULong64_t evt_id, Channel ch)
     {
         if (ch == Channel::SL)
         {
-            return m_estimator_sl.EstimateMass(jets, leptons, met, evt_id);
+            return m_estimator_sl.EstimateMass(jets, leptons, met, btags, light_tags, evt_id);
         }
         else if (ch == Channel::DL)
         {
-            return m_estimator_dl.EstimateMass(jets, leptons, met, evt_id);
+            return m_estimator_dl.EstimateMass(jets, leptons, met, btags, light_tags, evt_id);
         }
         else 
         {

--- a/Studies/HME/new/include/EstimatorBase.hpp
+++ b/Studies/HME/new/include/EstimatorBase.hpp
@@ -7,7 +7,6 @@
 #include "TRandom3.h"
 
 #include "Definitions.hpp"
-#include "EstimationRecorder.hpp"
 #include "Constants.hpp"
 
 namespace HME 
@@ -24,8 +23,13 @@ namespace HME
         EstimatorBase();
         virtual ~EstimatorBase() = default;
 
-        virtual ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, TString const& comb_label) = 0;
-        virtual OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id) = 0;
+        virtual ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, Float_t proba, TString const& comb_label) = 0;
+        virtual OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, 
+                                                     VecLVF_t const& leptons, 
+                                                     LorentzVectorF_t const& met, 
+                                                     std::vector<Float_t> const& btags,
+                                                     std::vector<Float_t> const& light_tags, 
+                                                     ULong64_t evt_id) = 0;
 
         protected:
         HistVec_t<TH1F> m_pdf_1d;

--- a/Studies/HME/new/include/EstimatorDoubleLep.hpp
+++ b/Studies/HME/new/include/EstimatorDoubleLep.hpp
@@ -210,16 +210,20 @@ namespace HME
                 {
                     estimations.push_back(comb_result);
                 }
-
-                // clear the histogram to be reused 
-                ResetHist(m_res_mass);
             }
         }
 
         // success: at least one combination produced an estimate of X->HH mass
         if (!estimations.empty())
         {
-            return std::make_optional<ArrF_t<ESTIM_OUT_SZ>>(estimations[0]);
+            ArrF_t<ESTIM_OUT_SZ> res{};
+            int binmax = m_res_mass->GetMaximumBin(); 
+            res[static_cast<size_t>(EstimOut::mass)] = m_res_mass->GetXaxis()->GetBinCenter(binmax);
+            res[static_cast<size_t>(EstimOut::peak_value)] = m_res_mass->GetBinContent(binmax);
+            res[static_cast<size_t>(EstimOut::width)] = ComputeWidth(m_res_mass, Q16, Q84);
+            res[static_cast<size_t>(EstimOut::integral)] = m_res_mass->Integral();
+            ResetHist(m_res_mass);
+            return std::make_optional<ArrF_t<ESTIM_OUT_SZ>>(res);
         }
         return std::nullopt;
     }

--- a/Studies/HME/new/include/EstimatorDoubleLep.hpp
+++ b/Studies/HME/new/include/EstimatorDoubleLep.hpp
@@ -23,8 +23,13 @@ namespace HME
         explicit EstimatorDoubleLep(TString const& pdf_file_name);
         ~EstimatorDoubleLep() override = default;
 
-        ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, TString const& comb_label) override;
-        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id) override;
+        ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, Float_t proba, TString const& comb_label) override;
+        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, 
+                                             VecLVF_t const& leptons, 
+                                             LorentzVectorF_t const& met, 
+                                             std::vector<Float_t> const& btags,
+                                             std::vector<Float_t> const& light_tags, 
+                                             ULong64_t evt_id) override;
     };
 
     EstimatorDoubleLep::EstimatorDoubleLep(TString const& pdf_file_name)
@@ -38,7 +43,7 @@ namespace HME
         pf->Close();
     }
 
-    ArrF_t<ESTIM_OUT_SZ> EstimatorDoubleLep::EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, TString const& comb_label)
+    ArrF_t<ESTIM_OUT_SZ> EstimatorDoubleLep::EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, Float_t proba, TString const& comb_label)
     {
         ArrF_t<ESTIM_OUT_SZ> res{};
         std::fill(res.begin(), res.end(), -1.0f);
@@ -148,7 +153,7 @@ namespace HME
             Float_t weight = estimates.empty() ? 0.0 : 1.0/estimates.size();
             for (auto est: estimates)
             {
-                m_res_mass->Fill(est, weight);
+                m_res_mass->Fill(est, proba*weight);
             }
         }
 
@@ -165,7 +170,12 @@ namespace HME
         return res;
     }
 
-    OptArrF_t<ESTIM_OUT_SZ> EstimatorDoubleLep::EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id)
+    OptArrF_t<ESTIM_OUT_SZ> EstimatorDoubleLep::EstimateMass(VecLVF_t const& jets, 
+                                                             VecLVF_t const& leptons, 
+                                                             LorentzVectorF_t const& met, 
+                                                             std::vector<Float_t> const& btags,
+                                                             std::vector<Float_t> const& light_tags, 
+                                                             ULong64_t evt_id)
     {
         VecLVF_t particles(static_cast<size_t>(ObjDL::count));
         particles[static_cast<size_t>(ObjDL::lep1)] = leptons[static_cast<size_t>(Lep::lep1)];
@@ -191,8 +201,9 @@ namespace HME
                     particles[static_cast<size_t>(ObjDL::bj2)] = jets[bj1_idx];
                 }
 
+                Float_t proba = btags[bj1_idx]*btags[bj2_idx];
                 TString comb_label = Form("b%zub%zu", bj1_idx, bj2_idx);
-                ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, comb_label);
+                ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, proba, comb_label);
 
                 // success: mass > 0
                 if (comb_result[static_cast<size_t>(EstimOut::mass)] > 0.0)

--- a/Studies/HME/new/include/EstimatorSingleLep.hpp
+++ b/Studies/HME/new/include/EstimatorSingleLep.hpp
@@ -173,78 +173,99 @@ namespace HME
                                                              std::vector<Float_t> const& light_tags, 
                                                              ULong64_t evt_id)
     {
-        VecLVF_t particles(static_cast<size_t>(ObjSL::count));
+        using JetIdxPair_t = std::pair<size_t, size_t>; 
+
+        std::vector<LorentzVectorF_t> particles(static_cast<size_t>(ObjSL::count));
         particles[static_cast<size_t>(ObjSL::lep)] = leptons[static_cast<size_t>(Lep::lep1)];
         particles[static_cast<size_t>(ObjSL::met)] = met;
+        m_res_mass->SetNameTitle("X_mass", Form("X->HH mass: event %llu", evt_id));
 
-        std::vector<ArrF_t<ESTIM_OUT_SZ>> results;
-        std::vector<Float_t> integrals;
-        size_t num_bjets = jets.size() < NUM_BEST_BTAG ? jets.size() : NUM_BEST_BTAG;
-
-        std::unordered_set<size_t> used;
-        for (size_t bj1_idx = 0; bj1_idx < num_bjets; ++bj1_idx)
+        size_t n_jets = jets.size();
+        size_t num_bjets = n_jets < NUM_BEST_BTAG ? n_jets : NUM_BEST_BTAG;
+        std::map<JetIdxPair_t, std::vector<JetIdxPair_t>> jet_comb_candidates;
+        for (size_t i = 0; i < num_bjets; ++i)
         {
-            used.insert(bj1_idx);
-            for (size_t bj2_idx = bj1_idx + 1; bj2_idx < num_bjets; ++bj2_idx)
+            for (size_t j = i + 1; j < num_bjets; ++j)
             {
-                used.insert(bj2_idx);
-                if (jets[bj1_idx].Pt() > jets[bj2_idx].Pt())
+                jet_comb_candidates.insert({{i, j}, std::vector<JetIdxPair_t>()});
+            }   
+        }
+
+        // fill possible light jet indices
+        // 2 jets are used to form a bjet pair => n - 2 jets can be light jet candidates
+        size_t num_light_jets = std::min(n_jets - 2, NUM_BEST_QVG);
+        for (auto& [bjet_pair, light_jet_idx_pairs]: jet_comb_candidates)
+        {
+            auto [bj1_idx, bj2_idx] = bjet_pair;
+            std::vector<size_t> light_jet_indices;
+            for (size_t lj_idx = 0; lj_idx < n_jets; ++lj_idx)
+            {
+                if (lj_idx == bj1_idx || lj_idx == bj2_idx)
                 {
-                    particles[static_cast<size_t>(ObjSL::bj1)] = jets[bj1_idx];
-                    particles[static_cast<size_t>(ObjSL::bj2)] = jets[bj2_idx];
+                    continue;
+                }
+                light_jet_indices.push_back(lj_idx);
+            }
+            
+            // sort light jet indices by btagPNetQvG to easily select NUM_BEST_QVG best
+            auto ScoreCmp = [&light_tags](size_t i, size_t j)
+            {
+                return light_tags[i] > light_tags[j];
+            };
+            std::sort(light_jet_indices.begin(), light_jet_indices.end(), ScoreCmp);
+
+            // form all possible pairs of light jets
+            for (size_t i = 0; i < num_light_jets; ++i)
+            {
+                for (size_t j = i + 1; j < num_light_jets; ++j)
+                {
+                    light_jet_idx_pairs.emplace_back(light_jet_indices[i], light_jet_indices[j]);
+                }   
+            }
+        }
+
+        // loop over combination and estimate mass for each
+        std::vector<ArrF_t<ESTIM_OUT_SZ>> estimations;
+        for (auto const& [bjet_idx_pair, light_jet_idx_pairs]: jet_comb_candidates)
+        {
+            auto [bj1_idx, bj2_idx] = bjet_idx_pair;
+            if (jets[bj1_idx].Pt() > jets[bj2_idx].Pt())
+            {
+                particles[static_cast<size_t>(ObjSL::bj1)] = jets[bj1_idx];
+                particles[static_cast<size_t>(ObjSL::bj2)] = jets[bj2_idx];
+            }
+            else 
+            {
+                particles[static_cast<size_t>(ObjSL::bj1)] = jets[bj2_idx];
+                particles[static_cast<size_t>(ObjSL::bj2)] = jets[bj1_idx];
+            }
+
+            for (auto const& [lj1_idx, lj2_idx]: light_jet_idx_pairs)
+            {
+                if (jets[lj1_idx].Pt() > jets[lj2_idx].Pt())
+                {
+                    particles[static_cast<size_t>(ObjSL::lj1)] = jets[lj1_idx];
+                    particles[static_cast<size_t>(ObjSL::lj2)] = jets[lj2_idx];
                 }
                 else 
                 {
-                    particles[static_cast<size_t>(ObjSL::bj1)] = jets[bj2_idx];
-                    particles[static_cast<size_t>(ObjSL::bj2)] = jets[bj1_idx];
+                    particles[static_cast<size_t>(ObjSL::lj1)] = jets[lj2_idx];
+                    particles[static_cast<size_t>(ObjSL::lj2)] = jets[lj1_idx];
                 }
 
-                for (size_t lj1_idx = 0; lj1_idx < jets.size(); ++lj1_idx)
+                Float_t proba = btags[bj1_idx]*btags[bj2_idx]*light_tags[lj1_idx]*light_tags[lj2_idx];
+                TString comb_label = Form("b%zub%zuq%zuq%zu", bj1_idx, bj2_idx, lj1_idx, lj2_idx);
+                ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, proba, comb_label);
+
+                // success: mass > 0
+                if (comb_result[static_cast<size_t>(EstimOut::mass)] > 0.0)
                 {
-                    if (used.count(lj1_idx))
-                    {
-                        continue;
-                    }
-                    used.insert(lj1_idx);
-
-                    for (size_t lj2_idx = lj1_idx + 1; lj2_idx < jets.size(); ++lj2_idx)
-                    {
-                        if (used.count(lj2_idx))
-                        {
-                            continue;
-                        }
-                        used.insert(lj2_idx);
-
-                        if (jets[lj1_idx].Pt() > jets[lj2_idx].Pt())
-                        {
-                            particles[static_cast<size_t>(ObjSL::lj1)] = jets[lj1_idx];
-                            particles[static_cast<size_t>(ObjSL::lj2)] = jets[lj2_idx];
-                        }
-                        else 
-                        {
-                            particles[static_cast<size_t>(ObjSL::lj1)] = jets[lj2_idx];
-                            particles[static_cast<size_t>(ObjSL::lj2)] = jets[lj1_idx];
-                        }
-                        
-                        Float_t proba = btags[bj1_idx]*btags[bj2_idx]*light_tags[lj1_idx]*light_tags[lj2_idx];
-                        TString comb_label = Form("b%zub%zuq%zuq%zu", bj1_idx, bj2_idx, lj1_idx, lj2_idx);
-                        ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, proba, comb_label);
-                        if (comb_result[static_cast<size_t>(EstimOut::mass)] > 0.0)
-                        {
-                            results.push_back(comb_result);
-                            integrals.push_back(comb_result[static_cast<size_t>(EstimOut::integral)]);
-                        }
-
-                        used.erase(lj2_idx);
-                    }
-                    used.erase(lj1_idx);
+                    estimations.push_back(comb_result);
                 }
-                used.erase(bj2_idx);
             }
-            used.erase(bj1_idx);
         }
 
-        if (!results.empty())
+        if (!estimations.empty())
         {
             ArrF_t<ESTIM_OUT_SZ> res{};
             int binmax = m_res_mass->GetMaximumBin(); 

--- a/Studies/HME/new/include/EstimatorSingleLep.hpp
+++ b/Studies/HME/new/include/EstimatorSingleLep.hpp
@@ -235,9 +235,6 @@ namespace HME
                             integrals.push_back(comb_result[static_cast<size_t>(EstimOut::integral)]);
                         }
 
-                        // reset m_res_mass and use "clean" hist to build distribution for each combination
-                        // else keep filling histogram and only reset it when moving to another event
-                        ResetHist(m_res_mass);
                         used.erase(lj2_idx);
                     }
                     used.erase(lj1_idx);
@@ -249,10 +246,14 @@ namespace HME
 
         if (!results.empty())
         {
-            auto it = std::max_element(integrals.begin(), integrals.end());
-            size_t choice = it - integrals.begin();           
+            ArrF_t<ESTIM_OUT_SZ> res{};
+            int binmax = m_res_mass->GetMaximumBin(); 
+            res[static_cast<size_t>(EstimOut::mass)] = m_res_mass->GetXaxis()->GetBinCenter(binmax);
+            res[static_cast<size_t>(EstimOut::peak_value)] = m_res_mass->GetBinContent(binmax);
+            res[static_cast<size_t>(EstimOut::width)] = ComputeWidth(m_res_mass, Q16, Q84);
+            res[static_cast<size_t>(EstimOut::integral)] = m_res_mass->Integral();
             ResetHist(m_res_mass);
-            return std::make_optional<ArrF_t<ESTIM_OUT_SZ>>(results[choice]);
+            return std::make_optional<ArrF_t<ESTIM_OUT_SZ>>(res);
         }
         ResetHist(m_res_mass);
         return std::nullopt;

--- a/Studies/HME/new/include/EstimatorSingleLep.hpp
+++ b/Studies/HME/new/include/EstimatorSingleLep.hpp
@@ -15,8 +15,13 @@ namespace HME
         explicit EstimatorSingleLep(TString const& pdf_file_name);
         ~EstimatorSingleLep() override = default;
 
-        ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, TString const& comb_label) override;
-        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id) override;
+        ArrF_t<ESTIM_OUT_SZ> EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, Float_t proba, TString const& comb_label) override;
+        OptArrF_t<ESTIM_OUT_SZ> EstimateMass(VecLVF_t const& jets, 
+                                             VecLVF_t const& leptons, 
+                                             LorentzVectorF_t const& met, 
+                                             std::vector<Float_t> const& btags,
+                                             std::vector<Float_t> const& light_tags, 
+                                             ULong64_t evt_id) override;
     };
 
     
@@ -32,7 +37,7 @@ namespace HME
     }
 
 
-    ArrF_t<ESTIM_OUT_SZ> EstimatorSingleLep::EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, TString const& comb_label)
+    ArrF_t<ESTIM_OUT_SZ> EstimatorSingleLep::EstimateCombination(VecLVF_t const& particles, ULong64_t evt_id, Float_t proba, TString const& comb_label)
     {
         ArrF_t<ESTIM_OUT_SZ> res{};
         std::fill(res.begin(), res.end(), -1.0f);
@@ -143,7 +148,7 @@ namespace HME
             Float_t weight = 1.0/num_sol;
             for (auto mass: masses)
             {
-                m_res_mass->Fill(mass, weight);
+                m_res_mass->Fill(mass, weight*proba);
             }
         }
 
@@ -161,7 +166,12 @@ namespace HME
         return res;
     }
 
-    OptArrF_t<ESTIM_OUT_SZ> EstimatorSingleLep::EstimateMass(VecLVF_t const& jets, VecLVF_t const& leptons, LorentzVectorF_t const& met, ULong64_t evt_id)
+    OptArrF_t<ESTIM_OUT_SZ> EstimatorSingleLep::EstimateMass(VecLVF_t const& jets, 
+                                                             VecLVF_t const& leptons, 
+                                                             LorentzVectorF_t const& met, 
+                                                             std::vector<Float_t> const& btags,
+                                                             std::vector<Float_t> const& light_tags, 
+                                                             ULong64_t evt_id)
     {
         VecLVF_t particles(static_cast<size_t>(ObjSL::count));
         particles[static_cast<size_t>(ObjSL::lep)] = leptons[static_cast<size_t>(Lep::lep1)];
@@ -216,8 +226,9 @@ namespace HME
                             particles[static_cast<size_t>(ObjSL::lj2)] = jets[lj1_idx];
                         }
                         
+                        Float_t proba = btags[bj1_idx]*btags[bj2_idx]*light_tags[lj1_idx]*light_tags[lj2_idx];
                         TString comb_label = Form("b%zub%zuq%zuq%zu", bj1_idx, bj2_idx, lj1_idx, lj2_idx);
-                        ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, comb_label);
+                        ArrF_t<ESTIM_OUT_SZ> comb_result = EstimateCombination(particles, evt_id, proba, comb_label);
                         if (comb_result[static_cast<size_t>(EstimOut::mass)] > 0.0)
                         {
                             results.push_back(comb_result);

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -22,7 +22,15 @@ tagger_name: "particleNet"
 bjet_preselection_branch : "Jet_sel"
 
 payload_producers: 
-  HME:
+  SingleLepHME:
+    producers_module_name: Analysis.PayloadProducers
+    producer_name: HMEProducer 
+    channel: "SL"
+    columns: 
+      - mass
+      - valid
+    dependencies:
+  DoubleLepHME:
     producers_module_name: Analysis.PayloadProducers
     producer_name: HMEProducer 
     channel: "DL"

--- a/config/plot/histograms.yaml
+++ b/config/plot/histograms.yaml
@@ -2501,7 +2501,14 @@ PuppiMET_phi:
   max_y_sf: 1.5
   divide_by_bin_width: False
 
-HME_mass:
+SingleLepHME_mass:
+  x_bins: "100|-10:2500"
+  y_title: "Events"
+  use_log_y: False
+  max_y_sf: 1.5
+  divide_by_bin_width: False
+
+DoubleLepHME_mass:
   x_bins: "100|-10:2500"
   y_title: "Events"
   use_log_y: False


### PR DESCRIPTION
PR implements following:
- enables running HME for single lepton channel and double lepton channel separately
- adds tagger weights to estimator
- improves looping over jet combinations in single lepton channel 

Now producers can be run via
```law run AnalysisCacheTask --version dev --period Run3_2022 --workflow local --producer-to-run SingleLepHME``` and ```law run AnalysisCacheTask --version dev --period Run3_2022 --workflow local --producer-to-run DoubleLepHME```