### PR TITLE
replaced Hist Helper path

### DIFF
--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -2,7 +2,7 @@ import ROOT
 if __name__ == "__main__":
     sys.path.append(os.environ['ANALYSIS_PATH'])
 
-from FLAF.Analysis.HistHelper import *
+from FLAF.Common.HistHelper import *
 from FLAF.Common.Utilities import *
 
 


### PR DESCRIPTION
This PR is created to allow compatibility with new FLAF dev.
The main change expected is to move HistHelper from FLAF/Analysis to FLAF/Common