### PR TITLE
Add Limit Setting to CI

### DIFF
--- a/.github/integration_cfg.yaml
+++ b/.github/integration_cfg.yaml
@@ -22,7 +22,7 @@ variables:
   TEST_TIMEOUT: "4h"
   HH_bbWW_extra_commands:
     "
-      cmsEnv python3 StatInference/dc_make/create_datacards.py --input /builds/cms-flaf/flaf_integration/output/HH_bbWW/CI/Hists_merged/Run3_2023BPix/ --output CI_datacard --config config/Datacards/CI_card.yaml --hist-bins config/CI_binning.json --param_values 300 &&
+      cmsEnv python3 StatInference/dc_make/create_datacards.py --input /builds/cms-flaf/flaf_integration/output/HH_bbWW/CI/Hists_merged/Run3_2023BPix/ --output CI_datacard --config config/Datacards/CI_card.yaml --hist-bins config/Datacards/CI_binning.json --param_values 300 &&
       law run MergeResonantLimits --version dev --datacards 'CI_datacard/*.txt' --remove-output 3,a,y
     "
 

--- a/.github/integration_cfg.yaml
+++ b/.github/integration_cfg.yaml
@@ -20,6 +20,12 @@ variables:
   HH_bbWW_args: "--branches 0 --test 1000"
   HH_bbWW_eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix"
   TEST_TIMEOUT: "4h"
+  HH_bbWW_extra_commands:
+    "
+      cmsEnv python3 StatInference/dc_make/create_datacards.py --input /builds/cms-flaf/flaf_integration/output/HH_bbWW/CI/Hists_merged/Run3_2023BPix/ --output CI_datacard --config config/Datacards/CI_card.yaml --hist-bins config/CI_binning.json --param_values 300 &&
+      law run MergeResonantLimits --version dev --datacards 'CI_datacard/*.txt' --remove-output 3,a,y
+    "
+
 
 gitlab_url: "https://gitlab.cern.ch/api/v4/projects/210600/trigger/pipeline"
 gitlab_branch: "master"

--- a/.github/integration_cfg.yaml
+++ b/.github/integration_cfg.yaml
@@ -20,12 +20,6 @@ variables:
   HH_bbWW_args: "--branches 0 --test 1000"
   HH_bbWW_eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix"
   TEST_TIMEOUT: "4h"
-  HH_bbWW_extra_commands:
-    "
-      cmsEnv python3 StatInference/dc_make/create_datacards.py --input /builds/cms-flaf/flaf_integration/output/HH_bbWW/CI/Hists_merged/Run3_2023BPix/ --output CI_datacard --config config/Datacards/CI_card.yaml --hist-bins config/Datacards/CI_binning.json --param_values 300 &&
-      law run MergeResonantLimits --version dev --datacards 'CI_datacard/*.txt' --remove-output 3,a,y
-    "
-
 
 gitlab_url: "https://gitlab.cern.ch/api/v4/projects/210600/trigger/pipeline"
 gitlab_branch: "master"

--- a/config/Datacards/CI_binning.json
+++ b/config/Datacards/CI_binning.json
@@ -1,0 +1,210 @@
+[
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "eE"
+        ],
+        "categories": [
+            "OS_Iso/res2b"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "eMu"
+        ],
+        "categories": [
+            "OS_Iso/res2b"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "muMu"
+        ],
+        "categories": [
+            "OS_Iso/res2b"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    0.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "eE"
+        ],
+        "categories": [
+            "OS_Iso/boosted"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    0.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+
+            "eMu"
+        ],
+        "categories": [
+            "OS_Iso/boosted"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    0.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "muMu"
+        ],
+        "categories": [
+            "OS_Iso/boosted"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "eE"
+        ],
+        "categories": [
+            "OS_Iso/recovery"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "eMu"
+        ],
+        "categories": [
+            "OS_Iso/recovery"
+        ],
+        "MX": [
+            300
+        ]
+    },
+    {
+        "combined_bins": [
+            {
+                "y_bin": [
+                    250.0,
+                    2500.0
+                ],
+                "x_bins": [
+                    0.0,
+                    1.0
+                ]
+            }
+        ],
+        "channels": [
+            "muMu"
+        ],
+        "categories": [
+            "OS_Iso/recovery"
+        ],
+        "MX": [
+            300
+        ]
+    }
+]

--- a/config/Datacards/CI_card.yaml
+++ b/config/Datacards/CI_card.yaml
@@ -1,0 +1,140 @@
+analysis: hh_bbww
+type: resonant
+model:
+  parameters: [ MX ]
+  param_dependent_bkg: true
+  input_file_pattern: DL_DNN_m${MX}_vs_HME/DL_DNN_m${MX}_vs_HME.root
+# hist_bins: [ 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 1 ]
+signalFractionForRelevantBins: 0.2
+eras:
+  - Run3_2022
+  - Run3_2022EE
+  - Run3_2023
+  - Run3_2023BPix
+channels:
+  - muMu
+  - eMu
+  - eE
+categories:
+  - OS_Iso/res2b
+  - OS_Iso/recovery
+processes:
+  - process: data_obs
+    is_data: true
+    is_asimov_data: true
+  - process: XtoHHto2B2W_2L_${MX} # GluGluToRadion2L_${MX}
+    hist_name: XtoHHto2B2W_2L_${MX} # GluGluToRadion2L_${MX}
+    param_values: [ 300 ]
+    is_signal: true
+    # 125.0 H->bb BR 5.824e-01 https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR
+    # 125.0 H->WW BR 2.137e-01
+    # 125.0 H->ZZ BR 2.619e-02
+    # W->lv 10.86e-02 https://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
+    # W->hadrons BR 67.41e-02 (1 - 3 * 10.86e-02)
+    # Z->ll 3.3658e-02
+    # Z->invisible 20e-02
+    # scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02 + 2 * 2.619E-02 * 3 * 3.3658e-02 * 20e-02)
+    # XtoHHto2B2W forces W decay, not allowing Zs
+    scale: 2 * 5.824e-01 * ( 2.137e-01 * 3 * 10.86e-02 * 3 * 10.86e-02)
+  - custom_CI_Background
+uncertainties:
+  - name: lumi_13p6TeV
+    type: lnN
+    value: 0.014 # https://twiki.cern.ch/twiki/bin/view/CMS/LumiRecommendationsRun3
+
+
+  - name: CMS_eff_m_id
+    type: shape
+  - name: CMS_eff_m_id_iso
+    type: shape
+  - name: EleID_TightIDIso
+    type: shape
+
+  - name: SingleEleTrg
+    type: shape
+  - name: SingleMuonTrg
+    type: shape
+
+  - name: CMS_pileup
+    type: shape
+
+  - name: CMS_scale_j
+    type: shape
+  - name: CMS_res_j
+    type: shape
+  - name: CMS_scale_e
+    type: shape
+
+
+  # For multiple values, Konstantin says do [ down, up ]
+  - name: QCD_scale_TT
+    type: lnN
+    processes:
+      - TT
+    value: [ -0.036, 0.025 ] # TT XS uncertainty in percentage from xsec yaml
+    # TT:
+    # crossSec: '923.6'
+    # reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO#Updated_reference_cross_sections
+    # unc: +22.6 -33.4 (scale) +/-  22.8 (PDF alphas) -24.6 +25.4 (mass) (to be multiplied by the BR)
+
+  - name: QCD_scale_DY
+    type: lnN
+    processes:
+      - DY
+    value: [ -0.011, 0.007 ] # DY XS uncertainty in percentage from xsec yaml
+    # DY_NNLO_QCD+NLO_EW:
+    # crossSec: 2094.2 * 3
+    # reference: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MATRIXCrossSectionsat13p6TeV
+    # unc: +0.7% - 1.1%, +- 1.0% PDF alphas
+
+  - name: QCD_scale_ST
+    type: lnN
+    processes:
+      - ST
+    value: [ -0.022, +0.022 ]
+    # Taken from ST to tW (largest uncertainty on XS) needs to be updated for each decay process later
+
+  - name: QCD_scale_VV
+    type: lnN
+    processes:
+      - VV
+    value: 0.005 # This was uncertainty from XSDB
+
+  - name: PDF_alphas
+    hasMultipleValues: True
+    type: lnN
+    value:
+      - value: 0.025
+        type: lnN
+        processes:
+          - TT
+      - value: 0.01
+        type: lnN
+        processes:
+          - DY
+      - value: 0.027
+        type: lnN
+        processes:
+          - ST
+
+  - name: top_mass
+    hasMultipleValues: True
+    type: lnN
+    value:
+      - value: [ -0.027, 0.028 ]
+        type: lnN
+        processes:
+          - TT
+      - value: [ -0.015, 0.015 ] # Taken from tW for now (largest unc percentage)
+        type: lnN
+        processes:
+          - ST
+
+autolnNThr: 0.1
+asymlnNThr: 0.001
+ignorelnNThr: 0.001
+autoMCStats:
+  apply: true
+  threshold: 20
+  apply_to_signal: true
+  mode: 1

--- a/config/Datacards/CI_card.yaml
+++ b/config/Datacards/CI_card.yaml
@@ -4,7 +4,6 @@ model:
   parameters: [ MX ]
   param_dependent_bkg: true
   input_file_pattern: DL_DNN_m${MX}_vs_HME/DL_DNN_m${MX}_vs_HME.root
-# hist_bins: [ 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 1 ]
 signalFractionForRelevantBins: 0.2
 eras:
   - Run3_2022
@@ -65,70 +64,6 @@ uncertainties:
   - name: CMS_scale_e
     type: shape
 
-
-  # For multiple values, Konstantin says do [ down, up ]
-  - name: QCD_scale_TT
-    type: lnN
-    processes:
-      - TT
-    value: [ -0.036, 0.025 ] # TT XS uncertainty in percentage from xsec yaml
-    # TT:
-    # crossSec: '923.6'
-    # reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO#Updated_reference_cross_sections
-    # unc: +22.6 -33.4 (scale) +/-  22.8 (PDF alphas) -24.6 +25.4 (mass) (to be multiplied by the BR)
-
-  - name: QCD_scale_DY
-    type: lnN
-    processes:
-      - DY
-    value: [ -0.011, 0.007 ] # DY XS uncertainty in percentage from xsec yaml
-    # DY_NNLO_QCD+NLO_EW:
-    # crossSec: 2094.2 * 3
-    # reference: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MATRIXCrossSectionsat13p6TeV
-    # unc: +0.7% - 1.1%, +- 1.0% PDF alphas
-
-  - name: QCD_scale_ST
-    type: lnN
-    processes:
-      - ST
-    value: [ -0.022, +0.022 ]
-    # Taken from ST to tW (largest uncertainty on XS) needs to be updated for each decay process later
-
-  - name: QCD_scale_VV
-    type: lnN
-    processes:
-      - VV
-    value: 0.005 # This was uncertainty from XSDB
-
-  - name: PDF_alphas
-    hasMultipleValues: True
-    type: lnN
-    value:
-      - value: 0.025
-        type: lnN
-        processes:
-          - TT
-      - value: 0.01
-        type: lnN
-        processes:
-          - DY
-      - value: 0.027
-        type: lnN
-        processes:
-          - ST
-
-  - name: top_mass
-    hasMultipleValues: True
-    type: lnN
-    value:
-      - value: [ -0.027, 0.028 ]
-        type: lnN
-        processes:
-          - TT
-      - value: [ -0.015, 0.015 ] # Taken from tW for now (largest unc percentage)
-        type: lnN
-        processes:
-          - ST
 
 autolnNThr: 0.1
 asymlnNThr: 0.001


### PR DESCRIPTION
Goal is to allow the CI robot to test limit setting code. This included a PR in the integration robot that should work without any new addition
https://gitlab.cern.ch/cms-flaf/flaf_integration/-/merge_requests/11


Once this 'extra_commands' argument is allowed, the idea is to have ours include 2 steps
```
create_datacards && law run MergeResonantLimits
```

Locally the data pathways are different than the CI. Locally this logic is working. 