### PR TITLE
Fixes based on observations during v2605 anaTuple production

### DIFF
--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -182,14 +182,30 @@ defaultColToSave = [
 
 # Add this functionality eventually
 MCObservables = [
-    "LHEPdfWeight",
-    "LHEReweightingWeight",
-    "nLHEPdfWeight",
-    "nLHEReweightingWeight",
-    "LHEScaleWeight",
-    "nLHEScaleWeight",
-    "PSWeight",
-    "nPSWeight",
+    ("LHEPdfWeight", "LHEPdf_Weight"),
+    ("LHEReweightingWeight", "LHEReweighting_Weight"),
+    ("LHEScaleWeight", "LHEScale_Weight"),
+    ("PSWeight", "PS_Weight"),
+    "LHEPart_eta",
+    "LHEPart_incomingpz",
+    "LHEPart_mass",
+    "LHEPart_pdgId",
+    "LHEPart_phi",
+    "LHEPart_pt",
+    "LHEPart_spin",
+    "LHEPart_status",
+    "nLHEPart",
+    "LHE_AlphaS",
+    "LHE_HT",
+    "LHE_HTIncoming",
+    "LHE_Nb",
+    "LHE_Nc",
+    "LHE_Nglu",
+    "LHE_Njets",
+    "LHE_NpLO",
+    "LHE_NpNLO",
+    "LHE_Nuds",
+    "LHE_Vpt",
 ]
 
 PtEtaPhiM = ["pt", "eta", "phi", "mass"]
@@ -538,6 +554,14 @@ def defineSignalVariables(dfw):
                 f"static_cast<float>(H_to_bb.leg_vis_p4[{b_quark - 1}].{var}())",
             )
 
+def defineOtherMCObservables(dfw):
+    for var in MCObservables:
+        if isinstance(var, tuple):
+            var_orig_name, var_new_name = var
+            dfw.DefineAndAppend(var_new_name, var_orig_name)
+        else:
+            dfw.colToSave.append(var)
+
 
 def addAllVariables(
     dfw,
@@ -587,6 +611,8 @@ def addAllVariables(
     defineFatJetVariables(dfw, isData)
     defineForwardJetVariables(dfw, isData)
     defineMETVariables(dfw, global_params["met_type"])
+    if not isData:
+        defineMCObservables(dfw)
 
     if trigger_class is not None:
         hltBranches = dfw.Apply(

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -554,6 +554,7 @@ def defineSignalVariables(dfw):
                 f"static_cast<float>(H_to_bb.leg_vis_p4[{b_quark - 1}].{var}())",
             )
 
+
 def defineOtherMCObservables(dfw):
     for var in MCObservables:
         if isinstance(var, tuple):

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -555,7 +555,7 @@ def defineSignalVariables(dfw):
             )
 
 
-def defineOtherMCObservables(dfw):
+def defineMCSpecificObservables(dfw):
     for var in MCObservables:
         if isinstance(var, tuple):
             var_orig_name, var_new_name = var
@@ -613,7 +613,7 @@ def addAllVariables(
     defineForwardJetVariables(dfw, isData)
     defineMETVariables(dfw, global_params["met_type"])
     if not isData:
-        defineMCObservables(dfw)
+        defineMCSpecificObservables(dfw)
 
     if trigger_class is not None:
         hltBranches = dfw.Apply(

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## How to run anaTuple production
 
-Current version `v2605`
+Current version `v2605a`
 
 1. Clone repository
    ```bash
-   git clone -b v2605 --recursive git@github.com:cms-flaf/HH_bbWW.git
+   git clone -b v2605a --recursive git@github.com:cms-flaf/HH_bbWW.git
    cd HH_bbWW
    git lfs pull
    source $PWD/env.sh
@@ -40,5 +40,5 @@ Current version `v2605`
 
 1. Run production
    ```bash
-   law run AnaTupleMergeTask --version v2605 --period ERA --parallel-jobs 1000 --AnaTupleFileTask-tasks-per-job 10
+   law run AnaTupleMergeTask --version v2605a --period ERA --parallel-jobs 1000 --AnaTupleFileTask-tasks-per-job 10
    ```

--- a/config/Run3_2022/processes.yaml
+++ b/config/Run3_2022/processes.yaml
@@ -84,6 +84,10 @@ DYto2Tau_M_50:
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
 
+DY_LO:
+  datasets:
+    - DYto2L_MLL_10to50_madgraphMLM
+
 TT:
   name: "t#bar{t}"
   color: "kGreen-3"  # eliminates need for plot.yaml
@@ -396,9 +400,9 @@ Data_Full:
     - Muon_Run2022C
     - Muon_Run2022D
     - SingleMuon_Run2022C
-    - DoubleMuon_Run2022C
-    - MuonEG_Run2022C
-    - MuonEG_Run2022D
+    # - DoubleMuon_Run2022C
+    # - MuonEG_Run2022C
+    # - MuonEG_Run2022D
 
 Data_EGamma:
   name: "Data EGamma"

--- a/config/Run3_2022EE/processes.yaml
+++ b/config/Run3_2022EE/processes.yaml
@@ -84,6 +84,10 @@ DYto2Tau_M_50:
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
 
+DY_LO:
+  datasets:
+    - DYto2L_MLL_10to50_madgraphMLM
+
 TT:
   name: "t#bar{t}"
   color: "kGreen-3"  # eliminates need for plot.yaml

--- a/config/Run3_2022EE/processes.yaml
+++ b/config/Run3_2022EE/processes.yaml
@@ -407,9 +407,9 @@ Data_Full:
     - Muon_Run2022E
     - Muon_Run2022F
     - Muon_Run2022G
-    - MuonEG_Run2022E
-    - MuonEG_Run2022F
-    - MuonEG_Run2022G
+    # - MuonEG_Run2022E
+    # - MuonEG_Run2022F
+    # - MuonEG_Run2022G
 
 Data_EGamma:
   name: "Data EGamma"

--- a/config/Run3_2023/processes.yaml
+++ b/config/Run3_2023/processes.yaml
@@ -82,6 +82,10 @@ DYto2Tau_M_50:
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
 
+DY_LO:
+  datasets:
+    - DYto2L_MLL_10to50_madgraphMLM
+
 TT:
   name: "t#bar{t}"
   color: "kGreen-3"  # eliminates need for plot.yaml
@@ -322,10 +326,10 @@ Data_Full:
     - Muon1_Run2023C_v3
     - Muon1_Run2023C_v4
 
-    - MuonEG_Run2023C_v1
-    - MuonEG_Run2023C_v2
-    - MuonEG_Run2023C_v3
-    - MuonEG_Run2023C_v4
+    # - MuonEG_Run2023C_v1
+    # - MuonEG_Run2023C_v2
+    # - MuonEG_Run2023C_v3
+    # - MuonEG_Run2023C_v4
 
 QCD_PT_Mu:
   name: "QCD MC PT binned MuEnrich"

--- a/config/Run3_2023BPix/processes.yaml
+++ b/config/Run3_2023BPix/processes.yaml
@@ -82,6 +82,11 @@ DYto2Tau_M_50:
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
 
+DY_LO:
+  datasets:
+    - DYto2L_MLL_10to50_madgraphMLM
+
+
 TT:
   name: "t#bar{t}"
   color: "kGreen-3"  # eliminates need for plot.yaml
@@ -314,8 +319,8 @@ Data_Full:
     - Muon1_Run2023D_v1
     - Muon1_Run2023D_v2
 
-    - MuonEG_Run2023D_v1
-    - MuonEG_Run2023D_v2
+    # - MuonEG_Run2023D_v1
+    # - MuonEG_Run2023D_v2
 
 QCD_PT_Mu:
   name: "QCD MC PT binned MuEnrich"

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -82,6 +82,12 @@ DYto2Tau_M_50:
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
 
+DY_LO:
+  datasets:
+    - DYto2E_MLL_10to50_madgraphMLM
+    - DYto2Mu_MLL_10to50_madgraphMLM
+    - DYto2Tau_MLL_10to50_madgraphMLM
+
 TT:
   name: "t#bar{t}"
   color: "kGreen-3"  # eliminates need for plot.yaml

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -10,6 +10,10 @@ WLCGFileSystem:
   localPathCacheValidity: 600
   verbose: 0
 
+runTokenServer:
+  host: cms-flaf.cern.ch
+  port: 5007
+
 nEventsPerFile:
   data: 1000000
   signals: 100000

--- a/config/phys_models.yaml
+++ b/config/phys_models.yaml
@@ -37,6 +37,7 @@ Production_Model:
     - ST
     - VV
     - W
+    - DY_LO
   signals:
     - XtoHHto2B2W_SingleLepton
     - XtoHHto2B2W_DoubleLepton


### PR DESCRIPTION
- Varios FLAF updates
- Added LO DY for 10 < m_ll < 50 GeV for anaTuple production
- Use the run token server
- Added more LHE and PS variables
- Removed MuonEG data (currently only single lepton triggers are used)