### PR TITLE
Redesign documentation (cms-flaf/FLAF#113)

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,48 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yaml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/deploy-docs.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+  deploy:
+    needs: validate
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-docs
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -1,0 +1,52 @@
+# Running the analysis
+
+The pipeline — anaTuples, observables, histograms, plots — is the **standard FLAF chain**; follow
+the **[FLAF full-workflow walkthrough](https://cms-flaf.github.io/FLAF/workflow/walkthrough/)** for
+the commands. This page collects what is **specific to HH→bb̄WW**.
+
+```sh
+ERA=Run3_2022
+VER=dev
+
+law run FLAF.Analysis.tasks.HistPlotTask --period $ERA --version $VER --workflow local --test 1000
+```
+
+## The b-tag-shape cache runs first
+
+HH→bb̄WW computes **b-tag shape** weights in a dedicated caching stage,
+`AnalysisCacheTask` (aggregated by `AnalysisCacheAggregationTask`), which LAW runs automatically
+before histogramming — see
+[FLAF → Task reference](https://cms-flaf.github.io/FLAF/reference/tasks/#analysiscachetask).
+
+!!! warning "Budget time for the cache on a cold start"
+    On a cold cache `AnalysisCacheTask` is **slow** (roughly an hour per branch), even for simple
+    variables. When iterating, reuse an existing cache instead of recomputing it, using a
+    [per-task version override](https://cms-flaf.github.io/FLAF/workflow/arguments/#per-task-version-overrides),
+    e.g. `--AnalysisCacheTask-version <existing> --AnalysisCacheAggregationTask-version <existing>`.
+
+## Mass reconstruction: DeepHME
+
+The HH mass is reconstructed with **DeepHME** (the bb̄WW counterpart to SVfit in bb̄ττ). It is part
+of the observable computation and requires no special command — it runs as part of the standard
+producer chain.
+
+## Categories
+
+HH→bb̄WW is analysed in **resolved** and **boosted** categories (low- and high-p_T HH topologies).
+Category and channel selection is driven by `config/global.yaml`; narrow or extend it there or via
+your [`user_custom.yaml`](https://cms-flaf.github.io/FLAF/configuration/user-custom/).
+
+## Choosing which variables to histogram
+
+As for any FLAF analysis, the variable set is controlled by the `variables:` list in
+`user_custom.yaml` (or `--variables`). A short list keeps test runs fast:
+
+```yaml
+variables:
+  - lep1_pt
+  - ggF_DNN_HH
+```
+
+## Statistical interpretation
+
+Continue to [Statistical inference](stat_inference.md) for datacards, limits and diagnostics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# HH → bb̄WW
+
+This is the documentation for the **HH→bb̄WW** analysis — the search for Higgs-boson pair
+production in the bb̄WW final state, built on the
+[FLAF framework](https://cms-flaf.github.io/FLAF/).
+
+!!! abstract "The common workflow lives in the FLAF docs"
+    HH→bb̄WW runs on FLAF, so installation, the task pipeline (NanoAOD → anaTuples → histograms →
+    plots), the configuration system, storage, eras and CI are **shared with every FLAF analysis**
+    and are documented once, in the **[FLAF documentation](https://cms-flaf.github.io/FLAF/)**:
+
+    - [Prerequisites & installation](https://cms-flaf.github.io/FLAF/getting-started/installation/)
+    - [Your first run](https://cms-flaf.github.io/FLAF/getting-started/first-run/)
+    - [Full workflow walkthrough](https://cms-flaf.github.io/FLAF/workflow/walkthrough/)
+    - [Command arguments](https://cms-flaf.github.io/FLAF/workflow/arguments/)
+
+    **This site covers only what is specific to HH→bb̄WW.**
+
+## What this analysis adds on top of FLAF
+
+| Ingredient | Purpose |
+|---|---|
+| **DeepHME** | Neural mass reconstruction of the HH system (the bb̄WW counterpart to SVfit). |
+| **B-tag-shape cache** | Per-event b-tag shape weights, pre-computed via `AnalysisCacheTask`. |
+| Resolved & boosted categories | Two topologies analysed (low- and high-p_T HH). |
+| **StatInference** | Datacards and limits (`x_hh_bbww_run3.yaml`). |
+
+Setup is in [Setup](setup.md); analysis-specific run notes in
+[Running the analysis](analysis.md); the statistics step in
+[Statistical inference](stat_inference.md).
+
+## Quickstart
+
+```sh
+git clone --recursive git@github.com:cms-flaf/HH_bbWW.git
+cd HH_bbWW
+git lfs pull                                   # HH_bbWW ships large files via git LFS
+source env.sh                                  # first time builds the environment
+voms-proxy-init -voms cms -rfc -valid 192:00
+law index --verbose
+```
+
+!!! warning "Run `git lfs pull` after cloning"
+    HH→bb̄WW stores some large files with [git LFS](https://git-lfs.com/). If `git lfs pull` is
+    skipped, those files are placeholder pointers and the analysis will fail in confusing ways.
+
+Then smoke-test the chain (see
+[FLAF → first run](https://cms-flaf.github.io/FLAF/getting-started/first-run/)):
+
+```sh
+law run FLAF.Analysis.tasks.HistPlotTask \
+  --version my_first_run --period Run3_2022 --workflow local --test 1000
+```
+
+New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/key-terms/) and
+[Concepts](https://cms-flaf.github.io/FLAF/concepts/architecture/) first.
+
+## Eras
+
+HH→bb̄WW runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023` and `Run3_2023BPix`.
+See [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,45 @@
+# Setup
+
+HH→bb̄WW is installed and run like any FLAF analysis. The general procedure — prerequisites (CERN
+account, CVMFS, grid certificate, SSH keys) and what the first `source env.sh` builds — is in the
+**[FLAF installation guide](https://cms-flaf.github.io/FLAF/getting-started/installation/)**. This
+page lists the HH→bb̄WW specifics.
+
+## Clone (with git LFS)
+
+```sh
+git clone --recursive git@github.com:cms-flaf/HH_bbWW.git
+cd HH_bbWW
+git lfs pull
+source env.sh
+```
+
+!!! danger "Two easy-to-miss steps"
+    - `--recursive` — pulls the submodules (without it, imports fail on empty directories).
+    - `git lfs pull` — fetches the large files HH→bb̄WW tracks with git LFS. Skipping it leaves
+      pointer placeholders instead of real files.
+
+    To run a specific central production, clone its tag, e.g. `git clone -b <version> --recursive …`.
+
+## Analysis-specific submodules
+
+| Submodule | Role |
+|---|---|
+| `DeepHME` | Neural reconstruction of the HH mass for bb̄WW. |
+| `SyncTool` | Synchronisation/validation tooling. |
+| `StatInference`, `inference` | Datacards and combine-based limits/fits (shared). |
+
+These build automatically as part of `source env.sh`; you do not set them up by hand.
+
+## Production model
+
+The production [physics model](https://cms-flaf.github.io/FLAF/configuration/processes-and-models/)
+for HH→bb̄WW is `Run3_Model` (set in `config/global.yaml`). For fast local tests, use `TestModel`
+in your [`user_custom.yaml`](https://cms-flaf.github.io/FLAF/configuration/user-custom/) instead.
+
+## Next
+
+- [Running the analysis](analysis.md) — the bb̄WW-specific run notes (DeepHME, b-tag-shape cache,
+  categories).
+- [FLAF → Full workflow](https://cms-flaf.github.io/FLAF/workflow/walkthrough/) — the common
+  pipeline, stage by stage.

--- a/docs/stat_inference.md
+++ b/docs/stat_inference.md
@@ -1,0 +1,51 @@
+# Statistical inference
+
+The final step turns the merged histograms into **datacards** and runs limits with
+[Combine](https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/), via the `StatInference` and
+`inference` submodules. See
+[FLAF → walkthrough, stage 5](https://cms-flaf.github.io/FLAF/workflow/walkthrough/#stage-5-statistical-inference)
+for where this sits in the pipeline.
+
+These commands run inside CMSSW/Combine, so prefix them with `cmsEnv` (or open one subshell):
+
+```sh
+cmsEnv /bin/zsh        # a CMSSW+Combine subshell
+```
+
+## 1. Create datacards
+
+```sh
+cmsEnv python3 StatInference/dc_make/create_datacards.py \
+  --input  PATH_TO_SHAPES \
+  --output PATH_TO_CARDS \
+  --config StatInference/config/x_hh_bbww_run3.yaml
+```
+
+The HH→bb̄WW Run 3 configuration is
+[`x_hh_bbww_run3.yaml`](https://github.com/cms-flaf/StatInference/blob/main/config/x_hh_bbww_run3.yaml).
+
+## 2. Run limits
+
+```sh
+law run PlotResonantLimits --version dev --datacards 'PATH_TO_CARDS/*.txt' --xsec fb --y-log
+```
+
+Hints:
+
+- add `--workflow htcondor` to submit to the batch system (local by default);
+- add `--remove-output 4,a,y` to clear previous outputs;
+- add `--print-status 0` to get the workflow status and the output file name;
+- options and background: the [cms-hh inference documentation](https://cms-hh.web.cern.ch/tools/inference/).
+
+## 3. Pulls & impacts
+
+```sh
+PlotPullsAndImpacts --version dev --datacards "PATH_TO_CARDS/<one_card>.txt" \
+  --hh-model NO_STR --parameter-values r=1 --parameter-ranges r,-100,100 \
+  --method robust --PlotPullsAndImpacts-order-by-impact True --mc-stats True \
+  --PullsAndImpacts-custom-args="--expectSignal=1"
+```
+
+!!! warning "One mass point at a time"
+    Run pulls & impacts on a **single** datacard, not a glob. Use `--print-status 0` to find the
+    output file and `--remove-output 4,a,y` to clear previous outputs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,6 @@ plugins:
 
 extra_javascript:
   - https://unpkg.com/mermaid@9.3/dist/mermaid.min.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,77 @@
+site_name: HH->bbWW
+site_description: >-
+  HH -> bb WW analysis built on the FLAF framework. Analysis-specific setup,
+  observables and statistical inference. The common pipeline is documented in the FLAF docs.
+repo_name: cms-flaf/HH_bbWW
+repo_url: https://github.com/cms-flaf/HH_bbWW
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  font: false
+  logo: https://cms.cern/sites/default/files/logo/cms_logo_neg03_2.png
+  features:
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
+    - navigation.footer
+    - navigation.indexes
+    - navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - def_list
+  - footnotes
+  - meta
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+plugins:
+  - search
+
+extra_javascript:
+  - https://unpkg.com/mermaid@9.3/dist/mermaid.min.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+nav:
+  - Home: index.md
+  - Setup: setup.md
+  - Running the analysis: analysis.md
+  - Statistical inference: stat_inference.md


### PR DESCRIPTION
Part of the FLAF documentation redesign — see cms-flaf/FLAF#113.

The common workflow is documented once in the FLAF docs; this repo gets a focused supplement covering only what is specific to **HH_bbWW**, linking back to the FLAF site for everything shared.

Adds/rewrites `docs/` + `mkdocs.yml` and a GitHub Pages **deploy workflow** (`.github/workflows/deploy-docs.yaml`).

**Testing:** `mkdocs build --strict` passes with no warnings; `mkdocs.yml` passes `yamllint`.