### PR TITLE
plots: scale signal overlays to summed background (signal_plot_scale: bkg)

### DIFF
--- a/config/global.yaml
+++ b/config/global.yaml
@@ -309,8 +309,9 @@ custom_regions: QCDRegions
 custom_categories: ""
 custom_subcategories: [ ]
 
-# Option to scale signal by some factor in HistPlotTask.py
-signal_plot_scale: 100.0
+# Signal overlay scaling in HistPlotTask: a fixed factor (e.g. 100), or "bkg" to
+# normalise each signal's integral to the summed background (shape comparison).
+signal_plot_scale: bkg
 
 # This is for Analysis Selection
 channelSelection:


### PR DESCRIPTION
## Summary

Switches signal-overlay scaling in plots from a fixed ×100 to **`signal_plot_scale: bkg`**, a new
capability of the redesigned PlotKit that normalises each signal's integral to the summed background
(shape comparison; the legend then reads `… (norm. to bkg)`).

Depends on the redesigned PlotKit (cms-flaf/FLAF#278, cms-flaf/PlotKit#1).

## Changes

- `config/global.yaml`: `signal_plot_scale: 100.0` → `bkg`.

## Testing

Verified on real `all_plots` Run3_2023 histograms via both the HistPlotTask plotting path and the
standalone CLI: the overlaid signals are each scaled to the total-background integral and labelled
`… (norm. to bkg)`, with the rest of the stacked plot unchanged.
