### PR TITLE
Enable CRAB workflow defaults and docs link

### DIFF
--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1012,3 +1012,7 @@ StatInference:
   config: config/Datacards/x_hh_bbww_DL_run3.yaml
   hist_bins: config/Datacards/CI_binning.json
   # param_values: [ 300 ]
+
+crab:
+  whitelist:
+    - T2_CH_CERN

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1012,7 +1012,3 @@ StatInference:
   config: config/Datacards/x_hh_bbww_DL_run3.yaml
   hist_bins: config/Datacards/CI_binning.json
   # param_values: [ 300 ]
-
-crab:
-  whitelist:
-    - T2_CH_CERN

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1012,3 +1012,6 @@ StatInference:
   config: config/Datacards/x_hh_bbww_DL_run3.yaml
   hist_bins: config/Datacards/CI_binning.json
   # param_values: [ 300 ]
+
+crab:
+  input_dataset: TTto2L2Nu

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1012,6 +1012,3 @@ StatInference:
   config: config/Datacards/x_hh_bbww_DL_run3.yaml
   hist_bins: config/Datacards/CI_binning.json
   # param_values: [ 300 ]
-
-crab:
-  input_dataset: /TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -1014,4 +1014,4 @@ StatInference:
   # param_values: [ 300 ]
 
 crab:
-  input_dataset: TTto2L2Nu
+  input_dataset: /TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -12,7 +12,7 @@ job_file_dir: $ANALYSIS_PATH/data/jobs
 job_file_dir_cleanup: False
 # CRAB (law.contrib.cms): CMSSW sandbox used by the CRAB client on the submit node.
 # Analysis outputs use fs_default; CRAB write-check site is derived from fs_default.
-# Optional site lists: config/global.yaml crab: (default all T1/T2/T3; see FLAF docs).
+# Optional site lists: config/global.yaml crab: (see FLAF docs: workflow/crab.md).
 crab_sandbox_name: CMSSW_14_0_0::arch=el9_amd64_gcc12
 
 [logging]

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -11,8 +11,8 @@ StatInference.law.tasks
 job_file_dir: $ANALYSIS_PATH/data/jobs
 job_file_dir_cleanup: False
 # CRAB (law.contrib.cms): CMSSW sandbox used by the CRAB client on the submit node.
-# Analysis outputs still use fs_default; crab.storage_site / crab.out_lfn_base come from
-# user_custom (see FLAF docs: workflow/crab.md).
+# Analysis outputs use fs_default; CRAB write-check site is derived from fs_default.
+# Site lists live in config/global.yaml under crab: (see FLAF docs: workflow/crab.md).
 crab_sandbox_name: CMSSW_14_0_0::arch=el9_amd64_gcc12
 
 [logging]

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -12,7 +12,7 @@ job_file_dir: $ANALYSIS_PATH/data/jobs
 job_file_dir_cleanup: False
 # CRAB (law.contrib.cms): CMSSW sandbox used by the CRAB client on the submit node.
 # Analysis outputs use fs_default; CRAB write-check site is derived from fs_default.
-# Site lists live in config/global.yaml under crab: (see FLAF docs: workflow/crab.md).
+# Optional site lists: config/global.yaml crab: (default all T1/T2/T3; see FLAF docs).
 crab_sandbox_name: CMSSW_14_0_0::arch=el9_amd64_gcc12
 
 [logging]

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -10,6 +10,10 @@ StatInference.law.tasks
 [job]
 job_file_dir: $ANALYSIS_PATH/data/jobs
 job_file_dir_cleanup: False
+# CRAB (law.contrib.cms): CMSSW sandbox used by the CRAB client on the submit node.
+# Analysis outputs still use fs_default; crab.storage_site / crab.out_lfn_base come from
+# user_custom (see FLAF docs: workflow/crab.md).
+crab_sandbox_name: CMSSW_14_0_0::arch=el9_amd64_gcc12
 
 [logging]
 luigi-interface: INFO

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -43,3 +43,5 @@ in your [`user_custom.yaml`](https://cms-flaf.github.io/FLAF/configuration/user-
   categories).
 - [FLAF → Full workflow](https://cms-flaf.github.io/FLAF/workflow/walkthrough/) — the common
   pipeline, stage by stage.
+- [FLAF → HTCondor](https://cms-flaf.github.io/FLAF/workflow/htcondor/) /
+  [CRAB](https://cms-flaf.github.io/FLAF/workflow/crab/) — CERN batch and full WLCG submission.


### PR DESCRIPTION
## Summary

Enables CRAB client sandbox defaults for HH_bbWW and documents the FLAF CRAB workflow page.

## Changes

- `config/law.cfg`: `crab_sandbox_name` (analysis outputs still use `fs_default`)
- `docs/setup.md`: link to FLAF CRAB documentation

## Dependency

Requires the FLAF PR **Add CRAB workflow support for remote LAW tasks** (`feature-crab-workflow`) for end-to-end CRAB runs.

## Testing

Full crab CI PASS for HH_bbWW / Run3_2022EE / TestModel / `--test 1000` with FLAF `feature-crab-workflow` (dev overlay).