### PR TITLE
Prepare HH_bbWW for Run3_2024 and Run3_2025

### DIFF
--- a/.github/workflows/test-setup-loading.yaml
+++ b/.github/workflows/test-setup-loading.yaml
@@ -12,5 +12,5 @@ jobs:
   test-setup-loading:
     uses: cms-flaf/FLAF/.github/workflows/test-setup-loading.yaml@main
     with:
-      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024"
+      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025"
     secrets: inherit

--- a/.github/workflows/test-setup-loading.yaml
+++ b/.github/workflows/test-setup-loading.yaml
@@ -12,5 +12,5 @@ jobs:
   test-setup-loading:
     uses: cms-flaf/FLAF/.github/workflows/test-setup-loading.yaml@main
     with:
-      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025"
+      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025 Run3_2026"
     secrets: inherit

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -414,6 +414,8 @@ def defineCentralJetVariables(dfw, isData):
     reco_jet_obs = list(JetObservables)
     if not isData:
         reco_jet_obs.extend(JetObservablesMC)
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    reco_jet_obs = [v for v in reco_jet_obs if f"Jet_{v}" in existing_cols]
     for jet_obs in reco_jet_obs:
         dfw.DefineAndAppend(
             f"centralJet_{jet_obs}",
@@ -434,6 +436,8 @@ def defineFatJetVariables(dfw, isData):
     fatjet_obs = list(FatJetObservables)
     if not isData:
         fatjet_obs.extend(FatJetObservablesMC)
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    fatjet_obs = [v for v in fatjet_obs if f"FatJet_{v}" in existing_cols]
 
     for var in PtEtaPhiM:
         dfw.DefineAndAppend(
@@ -448,6 +452,8 @@ def defineFatJetVariables(dfw, isData):
     subjet_obs = list(SubJetObservables)
     if not isData:
         subjet_obs.extend(SubJetObservablesMC)
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    subjet_obs = [v for v in subjet_obs if f"SubJet_{v}" in existing_cols]
     for subJetIdx in [1, 2]:
         dfw.Define(
             f"SelectedFatJet_subJetIdx{subJetIdx}",

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -606,6 +606,7 @@ def addAllVariables(
         min_n_effective_jets_DL=global_params["anaTupleSelection"][
             "min_n_effective_jets_DL"
         ],
+        era=global_params["era"],
     )
 
     defineCentralJetVariables(dfw, isData)

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -53,6 +53,7 @@ JetObservables = [
     "PNetRegPtRawRes",
     "rawFactor",
     "btagPNetB",
+    "btagUParTAK4B",
     "btagPNetCvB",
     "btagPNetCvL",
     # "btagPNetCvNotB",
@@ -79,6 +80,7 @@ JetObservables = [
     # "neMultiplicity",
     "ptRes",
     "idbtagPNetB",
+    "idbtagUParTAK4B",
     "area",
 ]  # 2024
 
@@ -379,8 +381,12 @@ def defineExtraLeptonVariables(dfw):
 def defineCentralJetVariables(dfw, isData):
     # save all selected reco jets
     dfw.Define("centralJet_idx", "CreateIndexes(Sum(Jet_sel))")
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    sort_score = (
+        "Jet_btagUParTAK4B" if "Jet_btagUParTAK4B" in existing_cols else "Jet_btagPNetB"
+    )
     dfw.Define(
-        "centralJet_idxSorted", "ReorderObjects(Jet_btagPNetB[Jet_sel], centralJet_idx)"
+        "centralJet_idxSorted", f"ReorderObjects({sort_score}[Jet_sel], centralJet_idx)"
     )
     for var in PtEtaPhiM:
         name = f"centralJet_{var}"

--- a/AnaProd/baseline.py
+++ b/AnaProd/baseline.py
@@ -115,7 +115,11 @@ def selectJets(df, *, min_n_effective_jets_SL, min_n_effective_jets_DL, era=None
         "ForwardJet_sel",
         "v_ops::pt(Jet_p4) > 20 && abs(v_ops::eta(Jet_p4)) > 2.5 && Jet_passJetIdTight",
     )
-    fatjet_id = "" if era in ("Run3_2024", "Run3_2025") else " && ( FatJet_jetId & 2 )"
+    fatjet_id = (
+        ""
+        if era in ("Run3_2024", "Run3_2025", "Run3_2026")
+        else " && ( FatJet_jetId & 2 )"
+    )
     df = df.Define(
         "FatJet_Incl",
         f"v_ops::pt(FatJet_p4) > 200 && abs(v_ops::eta(FatJet_p4)) < 2.5{fatjet_id}",

--- a/AnaProd/baseline.py
+++ b/AnaProd/baseline.py
@@ -106,7 +106,7 @@ def selectExtraLeptons(df):
     return df
 
 
-def selectJets(df, *, min_n_effective_jets_SL, min_n_effective_jets_DL):
+def selectJets(df, *, min_n_effective_jets_SL, min_n_effective_jets_DL, era=None):
     df = df.Define(
         "Jet_Incl",
         "v_ops::pt(Jet_p4) > 20 && abs(v_ops::eta(Jet_p4)) < 2.5 && Jet_passJetIdTight",
@@ -115,9 +115,10 @@ def selectJets(df, *, min_n_effective_jets_SL, min_n_effective_jets_DL):
         "ForwardJet_sel",
         "v_ops::pt(Jet_p4) > 20 && abs(v_ops::eta(Jet_p4)) > 2.5 && Jet_passJetIdTight",
     )
+    fatjet_id = "" if era in ("Run3_2024", "Run3_2025") else " && ( FatJet_jetId & 2 )"
     df = df.Define(
         "FatJet_Incl",
-        "v_ops::pt(FatJet_p4) > 200 && abs(v_ops::eta(FatJet_p4)) < 2.5 && ( FatJet_jetId & 2 ) ",
+        f"v_ops::pt(FatJet_p4) > 200 && abs(v_ops::eta(FatJet_p4)) < 2.5{fatjet_id}",
     )
     df = df.Define(
         "Jet_sel",

--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -78,12 +78,14 @@ def GetBTagWeight(global_cfg_dict, cat, applyBtag=False):
     return f"{btag_weight}*{btagshape_weight}"
 
 
-def GetWeight(weights_this_process):  # do you need all these args?
+def GetWeight(
+    weights_this_process, weight_base_name="weight_base"
+):  # do you need all these args?
     # weights_this_process is a set of corrections from global.yaml
     # e.g. {'lumi', 'dy_hhbbww', 'trigger', 'base', 'btag', 'dy_hhbbtautau', 'JER', 'pu', 'JEC', 'ele', 'gen', 'muScaRe', 'mu', 'eleES', 'fatjet', 'xs'}
 
     # weights_to_apply = ["weight_base", "ExtraDYWeight"]
-    weights_to_apply = ["weight_base"]
+    weights_to_apply = [weight_base_name]
     weights_to_apply_resolved = []
     weights_to_apply_boosted = []
 

--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -11,7 +11,11 @@ WorkingPointsParticleNet = {
     "Run3_2022EE": {"Loose": 0.0499, "Medium": 0.2605, "Tight": 0.6915},
     "Run3_2023": {"Loose": 0.0358, "Medium": 0.1917, "Tight": 0.6172},
     "Run3_2023BPix": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
-    # UParTAK4 WP values from BTV Summer24 NanoAODv15 (L/M/T).
+    "Run3_2024": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
+    "Run3_2025": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
+}
+WorkingPointsUParTAK4 = {
+    # BTV Summer24 NanoAODv15 (L/M/T).
     "Run3_2024": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
     "Run3_2025": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
 }
@@ -553,7 +557,7 @@ def AddDNNVariablesDL(df, isData=False):
     return df
 
 
-def defineJetSelections(df, isData, bTagWP=0.1919):
+def defineJetSelections(df, isData, period="Run3_2023BPix"):
     # Define vars to save
     jet_vars = [
         "p4",
@@ -563,6 +567,8 @@ def defineJetSelections(df, isData, bTagWP=0.1919):
         "mass",
         "btagPNetB",
         "idbtagPNetB",
+        "btagUParTAK4B",
+        "idbtagUParTAK4B",
         "rawFactor",
         "PNetRegPtRawCorr",
         "PNetRegPtRawCorrNeutrino",
@@ -616,14 +622,24 @@ def defineJetSelections(df, isData, bTagWP=0.1919):
 
     # Do not need a selection, we should just take the top 2 score Jets whether they pass the cut
     # df = df.Define("BJet_Sel", "centralJet_idbtagPNetB >= 1")
-    if "centralJet_idbtagPNetB" in existing_cols:
-        df = df.Define("BJet_Sel", "centralJet_idbtagPNetB >= -1")
+    if (
+        "centralJet_idbtagPNetB" in existing_cols
+        or "centralJet_idbtagUParTAK4B" in existing_cols
+    ):
+        id_sel = (
+            "centralJet_idbtagUParTAK4B"
+            if "centralJet_idbtagUParTAK4B" in existing_cols
+            else "centralJet_idbtagPNetB"
+        )
+        df = df.Define("BJet_Sel", f"{id_sel} >= -1")
     else:
         df = df.Define("BJet_Sel", "centralJet_pt >= 0.f")
+    use_upart = "centralJet_btagUParTAK4B" in existing_cols
+    sort_score = "centralJet_btagUParTAK4B" if use_upart else "centralJet_btagPNetB"
     df = df.Define("BJet_idx", "CreateIndexes(Sum(BJet_Sel))")
     df = df.Define(
         "BJet_idxSorted",
-        "Take(ReorderObjects(centralJet_btagPNetB[BJet_Sel], BJet_idx), min((int)BJet_idx.size(), 2))",
+        f"Take(ReorderObjects({sort_score}[BJet_Sel], BJet_idx), min((int)BJet_idx.size(), 2))",
     )
     for var in jet_vars:
         df = df.Define(
@@ -634,21 +650,39 @@ def defineJetSelections(df, isData, bTagWP=0.1919):
     df = df.Define("bjet1_isValid", "(Nbjets > 0)")
     df = df.Define("bjet2_isValid", "(Nbjets > 1)")
 
-    if "idbtagPNetB" in jet_vars:
+    if "idbtagUParTAK4B" in jet_vars:
+        id_branch = "idbtagUParTAK4B"
+        score_branch = None
+        bTagWP = None
+    elif "idbtagPNetB" in jet_vars:
+        id_branch = "idbtagPNetB"
+        score_branch = None
+        bTagWP = None
+    elif use_upart:
+        id_branch = None
+        score_branch = "btagUParTAK4B"
+        bTagWP = WorkingPointsUParTAK4.get(period, WorkingPointsParticleNet[period])[
+            "Medium"
+        ]
+    else:
+        id_branch = None
+        score_branch = "btagPNetB"
+        bTagWP = WorkingPointsParticleNet[period]["Medium"]
+    if id_branch is not None:
         df = df.Define(
-            "bjet1_isBTagged", "bjet1_isValid ? BJet_idbtagPNetB[0] >= 1 : 0"
+            "bjet1_isBTagged", f"bjet1_isValid ? BJet_{id_branch}[0] >= 1 : 0"
         )
         df = df.Define(
-            "bjet2_isBTagged", "bjet2_isValid ? BJet_idbtagPNetB[1] >= 1 : 0"
+            "bjet2_isBTagged", f"bjet2_isValid ? BJet_{id_branch}[1] >= 1 : 0"
         )
     else:
         df = df.Define(
             "bjet1_isBTagged",
-            f"bjet1_isValid ? BJet_btagPNetB[0] >= {bTagWP}f : 0",
+            f"bjet1_isValid ? BJet_{score_branch}[0] >= {bTagWP}f : 0",
         )
         df = df.Define(
             "bjet2_isBTagged",
-            f"bjet2_isValid ? BJet_btagPNetB[1] >= {bTagWP}f : 0",
+            f"bjet2_isValid ? BJet_{score_branch}[1] >= {bTagWP}f : 0",
         )
     df = df.Define(
         f"nBTaggedJets", "int(bjet1_isBTagged) + int(bjet2_isBTagged)"
@@ -1708,7 +1742,9 @@ def PrepareDfForHistograms(dfForHistograms, isData):
     dfForHistograms.df = defineAllP4(dfForHistograms.df)
     dfForHistograms.calculateMT()
     dfForHistograms.df = defineJetSelections(
-        dfForHistograms.df, isData, getattr(dfForHistograms, "bTagWP", 0.1919)
+        dfForHistograms.df,
+        isData,
+        getattr(dfForHistograms, "period", "Run3_2023BPix"),
     )
     dfForHistograms.df = AddDNNVariablesCommon(dfForHistograms.df, isData)
     dfForHistograms.df = AddDNNVariablesDL(dfForHistograms.df, isData)

--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -11,6 +11,9 @@ WorkingPointsParticleNet = {
     "Run3_2022EE": {"Loose": 0.0499, "Medium": 0.2605, "Tight": 0.6915},
     "Run3_2023": {"Loose": 0.0358, "Medium": 0.1917, "Tight": 0.6172},
     "Run3_2023BPix": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
+    # UParTAK4 WP values from BTV Summer24 NanoAODv15 (L/M/T).
+    "Run3_2024": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
+    "Run3_2025": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
 }
 
 

--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -13,11 +13,13 @@ WorkingPointsParticleNet = {
     "Run3_2023BPix": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
     "Run3_2024": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
     "Run3_2025": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
+    "Run3_2026": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
 }
 WorkingPointsUParTAK4 = {
     # BTV Summer24 NanoAODv15 (L/M/T).
     "Run3_2024": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
     "Run3_2025": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
+    "Run3_2026": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
 }
 
 

--- a/Analysis/hh_bbww.py
+++ b/Analysis/hh_bbww.py
@@ -553,7 +553,7 @@ def AddDNNVariablesDL(df, isData=False):
     return df
 
 
-def defineJetSelections(df, isData):
+def defineJetSelections(df, isData, bTagWP=0.1919):
     # Define vars to save
     jet_vars = [
         "p4",
@@ -589,6 +589,11 @@ def defineJetSelections(df, isData):
     if not isData:
         fatjet_vars = fatjet_vars + fatjet_mc_vars
         jet_vars = jet_vars + jet_mc_vars
+    existing_cols = {str(c) for c in df.GetColumnNames()}
+    jet_vars = [v for v in jet_vars if v == "p4" or f"centralJet_{v}" in existing_cols]
+    fatjet_vars = [
+        v for v in fatjet_vars if v == "p4" or f"SelectedFatJet_{v}" in existing_cols
+    ]
 
     # First step is to decide Hbb boosted
     # Take FatJets, mask by BTag and msoftdrop, sort by BTag Score
@@ -611,7 +616,10 @@ def defineJetSelections(df, isData):
 
     # Do not need a selection, we should just take the top 2 score Jets whether they pass the cut
     # df = df.Define("BJet_Sel", "centralJet_idbtagPNetB >= 1")
-    df = df.Define("BJet_Sel", "centralJet_idbtagPNetB >= -1")
+    if "centralJet_idbtagPNetB" in existing_cols:
+        df = df.Define("BJet_Sel", "centralJet_idbtagPNetB >= -1")
+    else:
+        df = df.Define("BJet_Sel", "centralJet_pt >= 0.f")
     df = df.Define("BJet_idx", "CreateIndexes(Sum(BJet_Sel))")
     df = df.Define(
         "BJet_idxSorted",
@@ -626,8 +634,22 @@ def defineJetSelections(df, isData):
     df = df.Define("bjet1_isValid", "(Nbjets > 0)")
     df = df.Define("bjet2_isValid", "(Nbjets > 1)")
 
-    df = df.Define("bjet1_isBTagged", "bjet1_isValid ? BJet_idbtagPNetB[0] >= 1 : 0")
-    df = df.Define("bjet2_isBTagged", "bjet2_isValid ? BJet_idbtagPNetB[1] >= 1 : 0")
+    if "idbtagPNetB" in jet_vars:
+        df = df.Define(
+            "bjet1_isBTagged", "bjet1_isValid ? BJet_idbtagPNetB[0] >= 1 : 0"
+        )
+        df = df.Define(
+            "bjet2_isBTagged", "bjet2_isValid ? BJet_idbtagPNetB[1] >= 1 : 0"
+        )
+    else:
+        df = df.Define(
+            "bjet1_isBTagged",
+            f"bjet1_isValid ? BJet_btagPNetB[0] >= {bTagWP}f : 0",
+        )
+        df = df.Define(
+            "bjet2_isBTagged",
+            f"bjet2_isValid ? BJet_btagPNetB[1] >= {bTagWP}f : 0",
+        )
     df = df.Define(
         f"nBTaggedJets", "int(bjet1_isBTagged) + int(bjet2_isBTagged)"
     )  # Used in bbtautau DY reweight, name configured in global.yaml
@@ -1685,7 +1707,9 @@ def PrepareDfForHistograms(dfForHistograms, isData):
     dfForHistograms.defineLeptonChannel()
     dfForHistograms.df = defineAllP4(dfForHistograms.df)
     dfForHistograms.calculateMT()
-    dfForHistograms.df = defineJetSelections(dfForHistograms.df, isData)
+    dfForHistograms.df = defineJetSelections(
+        dfForHistograms.df, isData, getattr(dfForHistograms, "bTagWP", 0.1919)
+    )
     dfForHistograms.df = AddDNNVariablesCommon(dfForHistograms.df, isData)
     dfForHistograms.df = AddDNNVariablesDL(dfForHistograms.df, isData)
     dfForHistograms.defineTriggers()

--- a/Analysis/histTupleDef.py
+++ b/Analysis/histTupleDef.py
@@ -91,6 +91,13 @@ def DefineWeightForHistograms(
     boosted_categories = global_params.get("boosted_categories", [])
     process_group = global_params["process_group"]
     weights_this_process = set(corrections.to_apply.keys())
+    # Mode "none" still loads btag (WP-id branches) but does not create SF
+    # columns. GetWeight must not multiply by weight_bTagShape_Central then.
+    btag_mode = (
+        corrections.to_apply.get("btag", {}).get("modes", {}).get("HistTuple", "none")
+    )
+    if btag_mode not in ("shape", "shape_and_norm", "wp"):
+        weights_this_process.discard("btag")
 
     total_weight_expression = (
         analysis.GetWeight(

--- a/Analysis/histTupleDef.py
+++ b/Analysis/histTupleDef.py
@@ -93,7 +93,12 @@ def DefineWeightForHistograms(
     weights_this_process = set(corrections.to_apply.keys())
 
     total_weight_expression = (
-        analysis.GetWeight(weights_this_process) if process_group != "data" else "1"
+        analysis.GetWeight(
+            weights_this_process,
+            weight_base_name=global_params.get("weight_base_branch", "weight_base"),
+        )
+        if process_group != "data"
+        else "1"
     )  # are we sure?
     weight_name = "final_weight"
     if weight_name not in dfw.df.GetColumnNames():

--- a/config/Run3_2024/datasets.yaml
+++ b/config/Run3_2024/datasets.yaml
@@ -5380,6 +5380,262 @@ XtoYHto2Tau2B_MX_4000_MY_125:
 # Finished X->YH->ttbb samples #
 
 
+# Non-resonant ggF (2024 DAS naming: Par-c2-kl-kt)
+GluGlutoHHto2B2V_kl_0p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2V_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2V_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2V_kl_2p45_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2V_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2V_kl_5p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2V_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2Vto2L2Nu_kl_0p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2Vto2L2Nu_kl_2p45_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2Vto2L2Nu_kl_5p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2WtoLNu2Q_kl_0p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2WtoLNu2Q_kl_1p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2WtoLNu2Q_kl_2p45_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+GluGlutoHHto2B2WtoLNu2Q_kl_5p00_kt_1p00_c2_0p00:
+  sampleType: HHnonRes
+  generator: powheg
+  crossSection: 1pb
+  nanoAOD:
+    v15: /GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+
+# VBF HH (2024 DAS naming: Par-CV-C2V-C3)
+VBFHHto2B2V_CV_1_C2V_0_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_1_C2V_1_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_2p12_C2V_3p87_C3_m5p96:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2V_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_2p12_C2V_3p87_C3_m5p96:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Vto2L2Nu_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_2p12_C2V_3p87_C3_m5p96:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39:
+  sampleType: HHnonRes
+  generator: madgraph
+  crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2WtoLNu2Q_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
+
 custom_CI:
   sampleType: HH
   crossSection: 1pb

--- a/config/Run3_2024/global.yaml
+++ b/config/Run3_2024/global.yaml
@@ -43,14 +43,14 @@ corrections:
     stage: AnaTuple
     apply_jet_horns_fix: true
   btag:
-    normCacheProducer: BtagShape
     stages: [ AnaTuple, HistTuple, AnalysisCache ]
     modes:
       AnaTuple: none
-      AnalysisCache: shape
-      HistTuple: shape_and_norm
+      AnalysisCache: none
+      HistTuple: none
     tagger: UParTAK4
     jetCollection: centralJet
+    wantShape: false
   dy_hhbbtautau:
     stages: [ AnalysisCache, HistTuple ]
     processes: [ DY_M_10to50, DYto2L_InclusivePlusBinned ]

--- a/config/Run3_2024/global.yaml
+++ b/config/Run3_2024/global.yaml
@@ -1,9 +1,59 @@
-triggerFile: config/Run3_2023BPix/triggers.yaml
+triggerFile: config/Run3_2024/triggers.yaml
+nano_version: v15
+met_type: PuppiMET
+nanoAODVersions:
+  data: v15
+  mc: v15
 corrections:
+  mu:
+    stages: [ HistTuple, AnalysisCache ]
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stages: [ HistTuple, AnalysisCache ]
+    mode: SF
+  ele: { stages: [ HistTuple, AnalysisCache ] }
+  fatjet:
+    stages: [ HistTuple, AnalysisCache ]
+    ana: bbWW
+    tagger: particleNetWithMass_HbbvsQCD
+    fatJetName: fatbjet
+  muScaRe: {
+    stage: AnaTuple,
+    mu_pt_for_ScaReApplication: "nano",
+    selection: "Muon_looseId",
+  }
+  eleES: { stages: [ AnaTuple, AnalysisCache ] }
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
   btag:
-    stages: [ AnaTuple, HistTuple ]
+    normCacheProducer: BtagShape
+    stages: [ AnaTuple, HistTuple, AnalysisCache ]
     modes:
-      AnaTuple: none # just load to define WP ID branches
-      HistTuple: none
+      AnaTuple: none
+      AnalysisCache: shape
+      HistTuple: shape_and_norm
     tagger: UParTAK4
     jetCollection: centralJet
+  dy_hhbbtautau:
+    stages: [ AnalysisCache, HistTuple ]
+    processes: [ DY_M_10to50, DYto2L_InclusivePlusBinned ]
+    njets_branch: Njets
+    ntags_branch: nBTaggedJets
+    pt_ll_gen: ll_pt_gen

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -7,10 +7,6 @@ DY:
 
 DYto2L_InclusivePlusBinned:
   processors: *DY_processors
-  corrections:
-    Vpt:
-      type: DY
-      stages: [ 'AnalysisCache', 'HistTuple' ]
   datasets:
     - DYto2E_M_50_amcatnloFXFX
     - DYto2E_M_50_0J_amcatnloFXFX

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -101,16 +101,6 @@ W:
     - WtoENu_amcatnloFXFX
     - WtoMuNu_amcatnloFXFX
     - WtoTauNu_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 VV_inclusive:
   name: "VV"

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -3,22 +3,35 @@ DY:
   color: "kAzure+7"
   sub_processes:
     - DY_M_10to50
-    - DYto2E_M_50
-    - DYto2Mu_M_50
-    - DYto2Tau_M_50
+    - DYto2L_InclusivePlusBinned
 
 DYto2L_InclusivePlusBinned:
-  processors: *DY_processors_allFlavors
+  processors: *DY_processors
   corrections:
     Vpt:
       type: DY
       stages: [ 'AnalysisCache', 'HistTuple' ]
-  datasets: [ ]
+  datasets:
+    - DYto2E_M_50_amcatnloFXFX
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
 
 DY_M_10to50:
   name: "DY M10to50"
   color: "kAzure+10"
-  datasets: [ ]
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
 
 DYto2E_M_50:
   processors: *DY_processors
@@ -33,42 +46,118 @@ DYto2Tau_M_50:
   datasets: [ ]
 
 DY_LO:
-  datasets: [ ]
+  datasets:
+    - DYto2E_MLL_10to50_madgraphMLM
+    - DYto2Mu_MLL_10to50_madgraphMLM
+    - DYto2Tau_MLL_10to50_madgraphMLM
 
 TT:
   name: "t#bar{t}"
-  color: "kGreen-3"  # eliminates need for plot.yaml
-  datasets: [ ]
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+    - TTtoLNu2Q
+    - TTto4Q
 
 ST:
   name: "ST"
   color: "kPink+1"
-  datasets: [ ]
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
 
 DY_LowMass:
   name: "DY M10to50"
   color: "kAzure+10"
-  datasets: [ ]
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
 
 DY_HighMass:
   name: "DY M50"
   color: "kAzure+7"
-  datasets: [ ]
+  datasets:
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
 
 W:
   name: "W"
-  color: "kGreen"  # eliminates need for plot.yaml
-  datasets: [ ]
+  color: "kGreen"
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
+
+VV_inclusive:
+  name: "VV"
+  color: "kViolet+1"
+  datasets:
+    - WW
+    - WZ
+    - ZZ
 
 VV:
   name: "VV"
-  color: "kGreen+2"  # eliminates need for inputs.yaml
-  datasets: [ ]
+  color: "kViolet+1"
+  datasets:
+    - WWto2L2Nu_powheg
+    - WWto4Q_powheg
+    - WWtoLNu2Q_powheg
+    - WZto3LNu_powheg
+    - WZto2L2Q_powheg
+    - WZtoLNu2Q_powheg
+    - ZZto2L2Nu_powheg
+    - ZZto2L2Q_powheg
+    - ZZto2Nu2Q_powheg
+    - ZZto4L_powheg
 
 SingleHiggs:
   name: "Single Higgs"
   color: "kRed"
-  datasets: [ ]
+  datasets:
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2B_M125
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - TTHtoNon2B_M125
+    - TTHto2B_M125
 
 XtoHHto2B2W_DoubleLepton:
   name: "XtoHHto2B2W_DoubleLepton"
@@ -119,33 +208,194 @@ XtoHHto2Tau2B:
       - [ '1000' ]
     plot_color: [ "kMagenta", "kCyan", "kGreen" ]
     channels: [ "e", "mu", "eE", "eMu", "muMu" ]
+  datasets: [ ]
+
+GluGlutoHHto2B2V:
+  name: "GluGlutoHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2V_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2V_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2V kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlack" ]
   datasets:
-    - XtoYHto2Tau2B_MX_300_MY_125
-    - XtoYHto2Tau2B_MX_400_MY_125
-    - XtoYHto2Tau2B_MX_500_MY_125
-    - XtoYHto2Tau2B_MX_550_MY_125
-    - XtoYHto2Tau2B_MX_600_MY_125
-    - XtoYHto2Tau2B_MX_650_MY_125
-    - XtoYHto2Tau2B_MX_700_MY_125
-    - XtoYHto2Tau2B_MX_800_MY_125
-    - XtoYHto2Tau2B_MX_900_MY_125
-    - XtoYHto2Tau2B_MX_1000_MY_125
-    - XtoYHto2Tau2B_MX_1200_MY_125
-    - XtoYHto2Tau2B_MX_1400_MY_125
-    - XtoYHto2Tau2B_MX_1600_MY_125
-    - XtoYHto2Tau2B_MX_1800_MY_125
-    - XtoYHto2Tau2B_MX_2000_MY_125
-    - XtoYHto2Tau2B_MX_2500_MY_125
-    - XtoYHto2Tau2B_MX_3000_MY_125
-    - XtoYHto2Tau2B_MX_3500_MY_125
-    - XtoYHto2Tau2B_MX_4000_MY_125
+    - GluGlutoHHto2B2V_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2Vto2L2Nu:
+  name: "GluGlutoHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2Vto2L2Nu_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2Vto2L2Nu_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2Vto2L2Nu kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - GluGlutoHHto2B2Vto2L2Nu_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2WtoLNu2Q:
+  name: "GluGlutoHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2WtoLNu2Q_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2WtoLNu2Q_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2WtoLNu2Q kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - GluGlutoHHto2B2WtoLNu2Q_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_5p00_kt_1p00_c2_0p00
+
+VBFHHto2B2V:
+  name: "VBFHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2V_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2V_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2V CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - VBFHHto2B2V_CV_1_C2V_0_C3_1
+    - VBFHHto2B2V_CV_1_C2V_1_C3_1
+    - VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2V_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2Vto2L2Nu:
+  name: "VBFHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2Vto2L2Nu_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2Vto2L2Nu_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2Vto2L2Nu CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2Vto2L2Nu_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2WtoLNu2Q:
+  name: "VBFHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2WtoLNu2Q_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2WtoLNu2Q_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2WtoLNu2Q CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2WtoLNu2Q_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39
 
 Data_Full:
   name: "Data"
-  datasets: [ ]
+  datasets:
+    - EGamma0_Run2024C
+    - EGamma0_Run2024D
+    - EGamma0_Run2024E
+    - EGamma0_Run2024F
+    - EGamma0_Run2024G
+    - EGamma0_Run2024H
+    - EGamma0_Run2024I_v1
+    - EGamma0_Run2024I_v2
+    - EGamma1_Run2024C
+    - EGamma1_Run2024D
+    - EGamma1_Run2024E
+    - EGamma1_Run2024F
+    - EGamma1_Run2024G
+    - EGamma1_Run2024H
+    - EGamma1_Run2024I_v1
+    - EGamma1_Run2024I_v2
+    - Muon0_Run2024C
+    - Muon0_Run2024D
+    - Muon0_Run2024E
+    - Muon0_Run2024F
+    - Muon0_Run2024G
+    - Muon0_Run2024H
+    - Muon0_Run2024I_v1
+    - Muon0_Run2024I_v2
+    - Muon1_Run2024C
+    - Muon1_Run2024D
+    - Muon1_Run2024E
+    - Muon1_Run2024F
+    - Muon1_Run2024G
+    - Muon1_Run2024H
+    - Muon1_Run2024I_v1
+    - Muon1_Run2024I_v2
 
 custom_CI:
   name: "custom for CI and test purposes"
   color: "kAzure+10"
   datasets:
     - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kBlack"
+  datasets:
+    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets:
+    - Muon0_Run2024C

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -388,7 +388,7 @@ custom_CI_Signal:
   name: "CI -- Signal"
   color: "kBlack"
   datasets:
-    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
 
 custom_CI_Data:
   name: "CI -- Data"

--- a/config/Run3_2025/datasets.yaml
+++ b/config/Run3_2025/datasets.yaml
@@ -1,0 +1,7 @@
+# 2025 official MC is reused from Run3_2024 (reuse_mc_from_era).
+custom_CI:
+  sampleType: HH
+  crossSection: 1pb
+  generator: powheg
+  fs_nanoAOD: T3_CH_CERNBOX:/store/user/vdamante/
+  dirName: "nanobbtt_2024"

--- a/config/Run3_2025/global.yaml
+++ b/config/Run3_2025/global.yaml
@@ -1,0 +1,59 @@
+triggerFile: config/Run3_2025/triggers.yaml
+nano_version: v15
+met_type: PuppiMET
+nanoAODVersions:
+  data: v15
+  mc: v15
+corrections:
+  mu:
+    stages: [ HistTuple, AnalysisCache ]
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stages: [ HistTuple, AnalysisCache ]
+    mode: SF
+  ele: { stages: [ HistTuple, AnalysisCache ] }
+  fatjet:
+    stages: [ HistTuple, AnalysisCache ]
+    ana: bbWW
+    tagger: particleNetWithMass_HbbvsQCD
+    fatJetName: fatbjet
+  muScaRe: {
+    stage: AnaTuple,
+    mu_pt_for_ScaReApplication: "nano",
+    selection: "Muon_looseId",
+  }
+  eleES: { stages: [ AnaTuple, AnalysisCache ] }
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
+  btag:
+    stages: [ AnaTuple, HistTuple, AnalysisCache ]
+    modes:
+      AnaTuple: none
+      AnalysisCache: none
+      HistTuple: none
+    tagger: UParTAK4
+    jetCollection: centralJet
+    wantShape: false
+  dy_hhbbtautau:
+    stages: [ AnalysisCache, HistTuple ]
+    processes: [ DY_M_10to50, DYto2L_InclusivePlusBinned ]
+    njets_branch: Njets
+    ntags_branch: nBTaggedJets
+    pt_ll_gen: ll_pt_gen

--- a/config/Run3_2025/processes.yaml
+++ b/config/Run3_2025/processes.yaml
@@ -1,0 +1,413 @@
+DY:
+  name: "DY"
+  color: "kAzure+7"
+  sub_processes:
+    - DY_M_10to50
+    - DYto2L_InclusivePlusBinned
+
+DYto2L_InclusivePlusBinned:
+  processors: *DY_processors
+  datasets:
+    - DYto2E_M_50_amcatnloFXFX
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+
+DY_M_10to50:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+
+DYto2E_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DYto2Mu_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DYto2Tau_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DY_LO:
+  datasets:
+    - DYto2E_MLL_10to50_madgraphMLM
+    - DYto2Mu_MLL_10to50_madgraphMLM
+    - DYto2Tau_MLL_10to50_madgraphMLM
+
+TT:
+  name: "t#bar{t}"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+    - TTtoLNu2Q
+    - TTto4Q
+
+ST:
+  name: "ST"
+  color: "kPink+1"
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
+
+DY_LowMass:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+
+DY_HighMass:
+  name: "DY M50"
+  color: "kAzure+7"
+  datasets:
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+
+W:
+  name: "W"
+  color: "kGreen"
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
+
+VV_inclusive:
+  name: "VV"
+  color: "kViolet+1"
+  datasets:
+    - WW
+    - WZ
+    - ZZ
+
+VV:
+  name: "VV"
+  color: "kViolet+1"
+  datasets:
+    - WWto2L2Nu_powheg
+    - WWto4Q_powheg
+    - WWtoLNu2Q_powheg
+    - WZto3LNu_powheg
+    - WZto2L2Q_powheg
+    - WZtoLNu2Q_powheg
+    - ZZto2L2Nu_powheg
+    - ZZto2L2Q_powheg
+    - ZZto2Nu2Q_powheg
+    - ZZto4L_powheg
+
+SingleHiggs:
+  name: "Single Higgs"
+  color: "kRed"
+  datasets:
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2B_M125
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - TTHtoNon2B_M125
+    - TTHto2B_M125
+
+XtoHHto2B2W_DoubleLepton:
+  name: "XtoHHto2B2W_DoubleLepton"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2B2Wto2B2L2Nu_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2B2W_2L_${MASS}
+    name_pattern: Xto2B2W 2L ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kBlack", "kBlue", "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets: [ ]
+
+XtoHHto2B2W_SingleLepton:
+  name: "XtoHHto2B2W_SingleLepton"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2B2Wto2B2Q1L1Nu_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2B2W_1L_${MASS}
+    name_pattern: Xto2B2W 1L ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kBlack", "kBlue", "kRed" ]
+    channels: [ "e", "mu" ]
+  datasets: [ ]
+
+XtoHHto2Tau2B:
+  name: "XtoHHto2Tau2B"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2Tau2B_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2Tau2B_${MASS}
+    name_pattern: Xto2Tau2B ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kMagenta", "kCyan", "kGreen" ]
+    channels: [ "e", "mu", "eE", "eMu", "muMu" ]
+  datasets: [ ]
+
+GluGlutoHHto2B2V:
+  name: "GluGlutoHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2V_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2V_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2V kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - GluGlutoHHto2B2V_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2Vto2L2Nu:
+  name: "GluGlutoHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2Vto2L2Nu_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2Vto2L2Nu_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2Vto2L2Nu kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - GluGlutoHHto2B2Vto2L2Nu_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2WtoLNu2Q:
+  name: "GluGlutoHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2WtoLNu2Q_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2WtoLNu2Q_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2WtoLNu2Q kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - GluGlutoHHto2B2WtoLNu2Q_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_5p00_kt_1p00_c2_0p00
+
+VBFHHto2B2V:
+  name: "VBFHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2V_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2V_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2V CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - VBFHHto2B2V_CV_1_C2V_0_C3_1
+    - VBFHHto2B2V_CV_1_C2V_1_C3_1
+    - VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2V_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2Vto2L2Nu:
+  name: "VBFHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2Vto2L2Nu_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2Vto2L2Nu_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2Vto2L2Nu CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2Vto2L2Nu_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2WtoLNu2Q:
+  name: "VBFHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2WtoLNu2Q_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2WtoLNu2Q_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2WtoLNu2Q CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2WtoLNu2Q_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39
+
+Data_Full:
+  name: "Data"
+  datasets:
+    - EGamma0_Run2025B_v1
+    - EGamma0_Run2025C_v1
+    - EGamma0_Run2025C_v2
+    - EGamma0_Run2025D_v1
+    - EGamma0_Run2025E_v1
+    - EGamma0_Run2025F_v1
+    - EGamma0_Run2025F_v2
+    - EGamma0_Run2025G_v1
+    - EGamma1_Run2025B_v1
+    - EGamma1_Run2025C_v1
+    - EGamma1_Run2025C_v2
+    - EGamma1_Run2025D_v1
+    - EGamma1_Run2025E_v1
+    - EGamma1_Run2025F_v1
+    - EGamma1_Run2025F_v2
+    - EGamma1_Run2025G_v1
+    - EGamma2_Run2025B_v1
+    - EGamma2_Run2025C_v1
+    - EGamma2_Run2025C_v2
+    - EGamma2_Run2025D_v1
+    - EGamma2_Run2025E_v1
+    - EGamma2_Run2025F_v1
+    - EGamma2_Run2025F_v2
+    - EGamma2_Run2025G_v1
+    - EGamma3_Run2025B_v1
+    - EGamma3_Run2025C_v1
+    - EGamma3_Run2025C_v2
+    - EGamma3_Run2025D_v1
+    - EGamma3_Run2025E_v1
+    - EGamma3_Run2025F_v1
+    - EGamma3_Run2025F_v2
+    - EGamma3_Run2025G_v1
+    - Muon0_Run2025B_v1
+    - Muon0_Run2025C_v1
+    - Muon0_Run2025C_v2
+    - Muon0_Run2025D_v1
+    - Muon0_Run2025E_v1
+    - Muon0_Run2025F_v1
+    - Muon0_Run2025F_v2
+    - Muon0_Run2025G_v1
+    - Muon1_Run2025B_v1
+    - Muon1_Run2025C_v1
+    - Muon1_Run2025C_v2
+    - Muon1_Run2025D_v1
+    - Muon1_Run2025E_v1
+    - Muon1_Run2025F_v1
+    - Muon1_Run2025F_v2
+    - Muon1_Run2025G_v1
+
+custom_CI:
+  name: "custom for CI and test purposes"
+  color: "kAzure+10"
+  datasets:
+    - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kBlack"
+  datasets:
+    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets:
+    - Muon0_Run2025B_v1

--- a/config/Run3_2025/processes.yaml
+++ b/config/Run3_2025/processes.yaml
@@ -101,16 +101,6 @@ W:
     - WtoENu_amcatnloFXFX
     - WtoMuNu_amcatnloFXFX
     - WtoTauNu_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 VV_inclusive:
   name: "VV"

--- a/config/Run3_2025/processes.yaml
+++ b/config/Run3_2025/processes.yaml
@@ -404,7 +404,7 @@ custom_CI_Signal:
   name: "CI -- Signal"
   color: "kBlack"
   datasets:
-    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
 
 custom_CI_Data:
   name: "CI -- Data"

--- a/config/Run3_2025/triggers.yaml
+++ b/config/Run3_2025/triggers.yaml
@@ -1,0 +1,173 @@
+singleIsoMu:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_IsoMu24
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 26"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
+      doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2022_Summer22EE": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2023_Summer23": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2023_Summer23BPix": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2024_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2025_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+      }
+
+singleIsoMuHT:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_Mu15_IsoVVVL_PFHT450
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 17"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+
+singleIsoEleHT:
+  channels:
+    - eE
+    - eMu
+    - e
+  path:
+    - HLT_Ele15_IsoVVVL_PFHT450
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 17"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+
+singleEleWpTight:
+  channels:
+    - eMu
+    - eE
+    - e
+  path:
+    - HLT_Ele30_WPTight_Gsf
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 32"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0
+      doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "Electron-HLT-SF",
+        "2022_Summer22EE": "Electron-HLT-SF",
+        "2023_Summer23": "Electron-HLT-SF",
+        "2023_Summer23BPix": "Electron-HLT-SF",
+        "2024_Summer24": "Electron-HLT-SF",
+        "2025_Summer24": "Electron-HLT-SF"
+      }
+
+diElec:
+  channels:
+    - e
+    - eE
+  path:
+    - HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id == 11 &&  (TrigObj_filterBits&16)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 14"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+diMuon:
+  channels:
+    - muMu
+    - mu
+  path:
+    - HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 19"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&16)!=0
+      doMatching: False
+
+EMu:
+  channels:
+    - e
+    - Mu
+    - eMu
+  path:
+    - HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 10"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&64)!=0
+      doMatching: False
+MuE:
+  channels:
+    - e
+    - Mu
+    - eMu
+  path:
+    - HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id == 13 & (TrigObj_filterBits&32)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 14"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&64)!=0
+      doMatching: False
+
+# QuadPFJet:
+#   channels:
+#     - mu
+#     - e
+#   path:
+#     - HLT_QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65
+#   legs:
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 75
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&8388608)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 55
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&2097152)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 45
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&256)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 40
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&16)!=0
+#       doMatching: False

--- a/config/Run3_2025/weights.yaml
+++ b/config/Run3_2025/weights.yaml
@@ -1,0 +1,40 @@
+norm:
+  PileUp_Lumi_MC:
+    expression: weight_base_pu{scale}_rel  * final_weight
+    name: CMS_pileup_{}
+  MuonID_SF_Iso_ID:
+    expression: weight_lep1_MuonID_SF_TightPFIso_TightID{scale}_rel * weight_lep2_MuonID_SF_TightPFIso_TightID{scale}_rel * final_weight
+    name: CMS_eff_m_id_iso_{}
+  MuonID_SF_ID:
+    expression: weight_lep1_MuonID_SF_TightID_Trk{scale}_rel * weight_lep2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+    name: CMS_eff_m_id_{}
+  # MuonID_TightID:
+  #   expression: weight_lep1_MuonID_SF_TightID_Trk{scale}_rel * weight_lep2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+  #   name: MuonID_TightID_{}
+  # MuonID_TightIDIso:
+  #   expression: weight_lep1_MuonID_SF_LoosePFIso{scale}_rel * weight_lep2_MuonID_SF_LoosePFIso{scale}_rel * final_weight
+  #   name: MuonID_TightIDIso_{}
+  EleID_TightIDIso:
+    expression: weight_lep1_EleSF_wp80iso_EleID{scale}_rel * weight_lep2_EleSF_wp80iso_EleID{scale}_rel * final_weight
+    name: EleID_TightIDIso_{}
+  EleID_TightIDNoIso:
+    expression: weight_lep1_EleSF_wp80noiso_EleID{scale}_rel * weight_lep2_EleSF_wp80noiso_EleID{scale}_rel * final_weight
+    name: EleID_TightIDNoIso_{}
+
+  SingleEleTrg:
+    expression: weight_lep1_TrgSF_singleEleWpTight_singleEle{scale}_rel * weight_lep2_TrgSF_singleEleWpTight_singleEle{scale}_rel * final_weight
+    name: SingleEleTrg_{}
+  SingleMuonTrg:
+    expression: weight_lep1_TrgSF_singleIsoMu_IsoMu24{scale}_rel * weight_lep2_TrgSF_singleIsoMu_IsoMu24{scale}_rel * final_weight
+    name: SingleMuonTrg_{}
+
+
+shape:
+  JER:
+    name: CMS_scale_j_{}
+  JES_Total:
+    name: CMS_res_j_{}
+  EleES:
+    name: CMS_scale_e_{}
+  ScaRe:
+    name: CMS_ScaRe_mu_{}

--- a/config/Run3_2026/datasets.yaml
+++ b/config/Run3_2026/datasets.yaml
@@ -1,0 +1,7 @@
+# 2026 official MC is reused from Run3_2024 (reuse_mc_from_era).
+custom_CI:
+  sampleType: HH
+  crossSection: 1pb
+  generator: powheg
+  fs_nanoAOD: T3_CH_CERNBOX:/store/user/vdamante/
+  dirName: "nanobbtt_2024"

--- a/config/Run3_2026/global.yaml
+++ b/config/Run3_2026/global.yaml
@@ -1,0 +1,59 @@
+triggerFile: config/Run3_2026/triggers.yaml
+nano_version: v15
+met_type: PuppiMET
+nanoAODVersions:
+  data: v15
+  mc: v15
+corrections:
+  mu:
+    stages: [ HistTuple, AnalysisCache ]
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stages: [ HistTuple, AnalysisCache ]
+    mode: SF
+  ele: { stages: [ HistTuple, AnalysisCache ] }
+  fatjet:
+    stages: [ HistTuple, AnalysisCache ]
+    ana: bbWW
+    tagger: particleNetWithMass_HbbvsQCD
+    fatJetName: fatbjet
+  muScaRe: {
+    stage: AnaTuple,
+    mu_pt_for_ScaReApplication: "nano",
+    selection: "Muon_looseId",
+  }
+  eleES: { stages: [ AnaTuple, AnalysisCache ] }
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
+  btag:
+    stages: [ AnaTuple, HistTuple, AnalysisCache ]
+    modes:
+      AnaTuple: none
+      AnalysisCache: none
+      HistTuple: none
+    tagger: UParTAK4
+    jetCollection: centralJet
+    wantShape: false
+  dy_hhbbtautau:
+    stages: [ AnalysisCache, HistTuple ]
+    processes: [ DY_M_10to50, DYto2L_InclusivePlusBinned ]
+    njets_branch: Njets
+    ntags_branch: nBTaggedJets
+    pt_ll_gen: ll_pt_gen

--- a/config/Run3_2026/processes.yaml
+++ b/config/Run3_2026/processes.yaml
@@ -1,0 +1,354 @@
+DY:
+  name: "DY"
+  color: "kAzure+7"
+  sub_processes:
+    - DY_M_10to50
+    - DYto2L_InclusivePlusBinned
+
+DYto2L_InclusivePlusBinned:
+  processors: *DY_processors
+  datasets:
+    - DYto2E_M_50_amcatnloFXFX
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+
+DY_M_10to50:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+
+DYto2E_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DYto2Mu_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DYto2Tau_M_50:
+  processors: *DY_processors
+  datasets: [ ]
+
+DY_LO:
+  datasets:
+    - DYto2E_MLL_10to50_madgraphMLM
+    - DYto2Mu_MLL_10to50_madgraphMLM
+    - DYto2Tau_MLL_10to50_madgraphMLM
+
+TT:
+  name: "t#bar{t}"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+    - TTtoLNu2Q
+    - TTto4Q
+
+ST:
+  name: "ST"
+  color: "kPink+1"
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
+
+DY_LowMass:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+
+DY_HighMass:
+  name: "DY M50"
+  color: "kAzure+7"
+  datasets:
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+
+W:
+  name: "W"
+  color: "kGreen"
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+
+VV_inclusive:
+  name: "VV"
+  color: "kViolet+1"
+  datasets:
+    - WW
+    - WZ
+    - ZZ
+
+VV:
+  name: "VV"
+  color: "kViolet+1"
+  datasets:
+    - WWto2L2Nu_powheg
+    - WWto4Q_powheg
+    - WWtoLNu2Q_powheg
+    - WZto3LNu_powheg
+    - WZto2L2Q_powheg
+    - WZtoLNu2Q_powheg
+    - ZZto2L2Nu_powheg
+    - ZZto2L2Q_powheg
+    - ZZto2Nu2Q_powheg
+    - ZZto4L_powheg
+
+SingleHiggs:
+  name: "Single Higgs"
+  color: "kRed"
+  datasets:
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2B_M125
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - TTHtoNon2B_M125
+    - TTHto2B_M125
+
+XtoHHto2B2W_DoubleLepton:
+  name: "XtoHHto2B2W_DoubleLepton"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2B2Wto2B2L2Nu_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2B2W_2L_${MASS}
+    name_pattern: Xto2B2W 2L ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kBlack", "kBlue", "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets: [ ]
+
+XtoHHto2B2W_SingleLepton:
+  name: "XtoHHto2B2W_SingleLepton"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2B2Wto2B2Q1L1Nu_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2B2W_1L_${MASS}
+    name_pattern: Xto2B2W 1L ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kBlack", "kBlue", "kRed" ]
+    channels: [ "e", "mu" ]
+  datasets: [ ]
+
+XtoHHto2Tau2B:
+  name: "XtoHHto2Tau2B"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: XtoYHto2Tau2B_MX_(\d+)_MY_125
+    parameters: [ MASS ]
+    process_name: XtoHHto2Tau2B_${MASS}
+    name_pattern: Xto2Tau2B ${MASS} GeV (x50)
+    to_plot:
+      - [ '300' ]
+      - [ '600' ]
+      - [ '1000' ]
+    plot_color: [ "kMagenta", "kCyan", "kGreen" ]
+    channels: [ "e", "mu", "eE", "eMu", "muMu" ]
+  datasets: [ ]
+
+GluGlutoHHto2B2V:
+  name: "GluGlutoHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2V_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2V_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2V kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - GluGlutoHHto2B2V_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2V_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2Vto2L2Nu:
+  name: "GluGlutoHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2Vto2L2Nu_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2Vto2L2Nu_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2Vto2L2Nu kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - GluGlutoHHto2B2Vto2L2Nu_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Vto2L2Nu_kl_5p00_kt_1p00_c2_0p00
+
+GluGlutoHHto2B2WtoLNu2Q:
+  name: "GluGlutoHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2WtoLNu2Q_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGlutoHHto2B2WtoLNu2Q_${kl}_${kt}_${c2}
+    name_pattern: GluGlutoHHto2B2WtoLNu2Q kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - GluGlutoHHto2B2WtoLNu2Q_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2WtoLNu2Q_kl_5p00_kt_1p00_c2_0p00
+
+VBFHHto2B2V:
+  name: "VBFHHto2B2V"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2V_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2V_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2V CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - VBFHHto2B2V_CV_1_C2V_0_C3_1
+    - VBFHHto2B2V_CV_1_C2V_1_C3_1
+    - VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2V_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2Vto2L2Nu:
+  name: "VBFHHto2B2Vto2L2Nu"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2Vto2L2Nu_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2Vto2L2Nu_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2Vto2L2Nu CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kRed" ]
+    channels: [ "eE", "eMu", "muMu" ]
+  datasets:
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1
+    - VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2Vto2L2Nu_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39
+
+VBFHHto2B2WtoLNu2Q:
+  name: "VBFHHto2B2WtoLNu2Q"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2WtoLNu2Q_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2WtoLNu2Q_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2WtoLNu2Q CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '1', '1' ]
+    plot_color: [ "kBlue" ]
+    channels: [ "e", "mu" ]
+  datasets:
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1
+    - VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4
+    - VBFHHto2B2WtoLNu2Q_CV_2p12_C2V_3p87_C3_m5p96
+    - VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2
+    - VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3
+    - VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43
+    - VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94
+    - VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36
+    - VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39
+
+Data_Full:
+  name: "Data"
+  datasets: [ ]  # 2026 data not yet catalogued
+
+custom_CI:
+  name: "custom for CI and test purposes"
+  color: "kAzure+10"
+  datasets:
+    - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kBlack"
+  datasets:
+    - GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets: [ ]  # 2026 data not yet catalogued

--- a/config/Run3_2026/processes.yaml
+++ b/config/Run3_2026/processes.yaml
@@ -328,7 +328,47 @@ VBFHHto2B2WtoLNu2Q:
 
 Data_Full:
   name: "Data"
-  datasets: [ ]  # 2026 data not yet catalogued
+  datasets:
+    - EGamma0_Run2026A_v1
+    - EGamma0_Run2026B_v1
+    - EGamma0_Run2026C_v1
+    - EGamma0_Run2026D_v1
+    - EGamma1_Run2026A_v1
+    - EGamma1_Run2026B_v1
+    - EGamma1_Run2026C_v1
+    - EGamma1_Run2026D_v1
+    - EGamma2_Run2026A_v1
+    - EGamma2_Run2026B_v1
+    - EGamma2_Run2026C_v1
+    - EGamma2_Run2026D_v1
+    - EGamma3_Run2026A_v1
+    - EGamma3_Run2026B_v1
+    - EGamma3_Run2026C_v1
+    - EGamma3_Run2026D_v1
+    - EGamma4_Run2026A_v1
+    - EGamma4_Run2026B_v1
+    - EGamma4_Run2026C_v1
+    - EGamma4_Run2026D_v1
+    - EGamma5_Run2026A_v1
+    - EGamma5_Run2026B_v1
+    - EGamma5_Run2026C_v1
+    - EGamma5_Run2026D_v1
+    - Muon0_Run2026A_v1
+    - Muon0_Run2026B_v1
+    - Muon0_Run2026C_v1
+    - Muon0_Run2026D_v1
+    - Muon1_Run2026A_v1
+    - Muon1_Run2026B_v1
+    - Muon1_Run2026C_v1
+    - Muon1_Run2026D_v1
+    - Muon2_Run2026A_v1
+    - Muon2_Run2026B_v1
+    - Muon2_Run2026C_v1
+    - Muon2_Run2026D_v1
+    - Muon3_Run2026A_v1
+    - Muon3_Run2026B_v1
+    - Muon3_Run2026C_v1
+    - Muon3_Run2026D_v1
 
 custom_CI:
   name: "custom for CI and test purposes"
@@ -351,4 +391,5 @@ custom_CI_Signal:
 custom_CI_Data:
   name: "CI -- Data"
   color: "kAzure+10"
-  datasets: [ ]  # 2026 data not yet catalogued
+  datasets:
+    - Muon0_Run2026A_v1

--- a/config/Run3_2026/triggers.yaml
+++ b/config/Run3_2026/triggers.yaml
@@ -1,0 +1,173 @@
+singleIsoMu:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_IsoMu24
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 26"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
+      doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2022_Summer22EE": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2023_Summer23": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2023_Summer23BPix": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2024_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2025_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+      }
+
+singleIsoMuHT:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_Mu15_IsoVVVL_PFHT450
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 17"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+
+singleIsoEleHT:
+  channels:
+    - eE
+    - eMu
+    - e
+  path:
+    - HLT_Ele15_IsoVVVL_PFHT450
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 17"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+
+singleEleWpTight:
+  channels:
+    - eMu
+    - eE
+    - e
+  path:
+    - HLT_Ele30_WPTight_Gsf
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 32"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0
+      doMatching: True
+      jsonTRGcorrection_key: {
+        "2022_Summer22": "Electron-HLT-SF",
+        "2022_Summer22EE": "Electron-HLT-SF",
+        "2023_Summer23": "Electron-HLT-SF",
+        "2023_Summer23BPix": "Electron-HLT-SF",
+        "2024_Summer24": "Electron-HLT-SF",
+        "2025_Summer24": "Electron-HLT-SF"
+      }
+
+diElec:
+  channels:
+    - e
+    - eE
+  path:
+    - HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id == 11 &&  (TrigObj_filterBits&16)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 14"
+      online_obj:
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+
+diMuon:
+  channels:
+    - muMu
+    - mu
+  path:
+    - HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ_Mass3p8
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 19"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&16)!=0
+      doMatching: False
+
+EMu:
+  channels:
+    - e
+    - Mu
+    - eMu
+  path:
+    - HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 10"
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&32)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&64)!=0
+      doMatching: False
+MuE:
+  channels:
+    - e
+    - Mu
+    - eMu
+  path:
+    - HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 25"
+      online_obj:
+        cut: TrigObj_id == 13 & (TrigObj_filterBits&32)!=0
+      doMatching: False
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 14"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&64)!=0
+      doMatching: False
+
+# QuadPFJet:
+#   channels:
+#     - mu
+#     - e
+#   path:
+#     - HLT_QuadPFJet70_50_40_35_PFBTagParticleNet_2BTagSum0p65
+#   legs:
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 75
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&8388608)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 55
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&2097152)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 45
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&256)!=0
+#       doMatching: False
+#     - offline_obj:
+#         type: Jet
+#         cut:  v_ops::pt(Jet_p4) > 40
+#       online_obj:
+#         cut: TrigObj_id == 1 && (TrigObj_filterBits&16)!=0
+#       doMatching: False

--- a/config/Run3_2026/triggers.yaml
+++ b/config/Run3_2026/triggers.yaml
@@ -17,7 +17,8 @@ singleIsoMu:
         "2023_Summer23": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
         "2023_Summer23BPix": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
         "2024_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
-        "2025_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
+        "2025_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight",
+        "2026_Summer24": "NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight"
       }
 
 singleIsoMuHT:
@@ -69,7 +70,8 @@ singleEleWpTight:
         "2023_Summer23": "Electron-HLT-SF",
         "2023_Summer23BPix": "Electron-HLT-SF",
         "2024_Summer24": "Electron-HLT-SF",
-        "2025_Summer24": "Electron-HLT-SF"
+        "2025_Summer24": "Electron-HLT-SF",
+        "2026_Summer24": "Electron-HLT-SF"
       }
 
 diElec:

--- a/config/Run3_2026/weights.yaml
+++ b/config/Run3_2026/weights.yaml
@@ -1,0 +1,40 @@
+norm:
+  PileUp_Lumi_MC:
+    expression: weight_base_pu{scale}_rel  * final_weight
+    name: CMS_pileup_{}
+  MuonID_SF_Iso_ID:
+    expression: weight_lep1_MuonID_SF_TightPFIso_TightID{scale}_rel * weight_lep2_MuonID_SF_TightPFIso_TightID{scale}_rel * final_weight
+    name: CMS_eff_m_id_iso_{}
+  MuonID_SF_ID:
+    expression: weight_lep1_MuonID_SF_TightID_Trk{scale}_rel * weight_lep2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+    name: CMS_eff_m_id_{}
+  # MuonID_TightID:
+  #   expression: weight_lep1_MuonID_SF_TightID_Trk{scale}_rel * weight_lep2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+  #   name: MuonID_TightID_{}
+  # MuonID_TightIDIso:
+  #   expression: weight_lep1_MuonID_SF_LoosePFIso{scale}_rel * weight_lep2_MuonID_SF_LoosePFIso{scale}_rel * final_weight
+  #   name: MuonID_TightIDIso_{}
+  EleID_TightIDIso:
+    expression: weight_lep1_EleSF_wp80iso_EleID{scale}_rel * weight_lep2_EleSF_wp80iso_EleID{scale}_rel * final_weight
+    name: EleID_TightIDIso_{}
+  EleID_TightIDNoIso:
+    expression: weight_lep1_EleSF_wp80noiso_EleID{scale}_rel * weight_lep2_EleSF_wp80noiso_EleID{scale}_rel * final_weight
+    name: EleID_TightIDNoIso_{}
+
+  SingleEleTrg:
+    expression: weight_lep1_TrgSF_singleEleWpTight_singleEle{scale}_rel * weight_lep2_TrgSF_singleEleWpTight_singleEle{scale}_rel * final_weight
+    name: SingleEleTrg_{}
+  SingleMuonTrg:
+    expression: weight_lep1_TrgSF_singleIsoMu_IsoMu24{scale}_rel * weight_lep2_TrgSF_singleIsoMu_IsoMu24{scale}_rel * final_weight
+    name: SingleMuonTrg_{}
+
+
+shape:
+  JER:
+    name: CMS_scale_j_{}
+  JES_Total:
+    name: CMS_res_j_{}
+  EleES:
+    name: CMS_scale_e_{}
+  ScaRe:
+    name: CMS_ScaRe_mu_{}

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -503,6 +503,7 @@ uncs_to_exclude:
   Run3_2023BPix: [ ]
   Run3_2024: [ ]
   Run3_2025: [ ]
+  Run3_2026: [ ]
 
 storeExtraJets: False
 scales:

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -501,6 +501,8 @@ uncs_to_exclude:
   Run3_2022EE: [ ]
   Run3_2023: [ ]
   Run3_2023BPix: [ ]
+  Run3_2024: [ ]
+  Run3_2025: [ ]
 
 storeExtraJets: False
 scales:

--- a/config/plot/Run3_2024.yaml
+++ b/config/plot/Run3_2024.yaml
@@ -1,0 +1,27 @@
+lumi_text:
+  text: "109.9 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0, -0.03 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'e': 'e'
+  'mu': '#mu'
+  'eE': 'ee'
+  'eMu': 'e #mu'
+  'muMu': '#mu #mu'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'
+  'ZVeto_OS_Iso': 'Z Veto, OS, Isolated'
+  'ZPeak_OS_Iso': 'Z Peak, OS, Isolated'
+  'SR': 'Signal Region'
+  'SR_mbb': 'Signal Region + m_bb Cut'
+  'TT_CR': 'TT Control Region'
+  'DY_CR': 'DY Control Region'
+  'W_CR': 'W Control Region'

--- a/config/plot/Run3_2025.yaml
+++ b/config/plot/Run3_2025.yaml
@@ -1,0 +1,27 @@
+lumi_text:
+  text: "110.7 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0, -0.03 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'e': 'e'
+  'mu': '#mu'
+  'eE': 'ee'
+  'eMu': 'e #mu'
+  'muMu': '#mu #mu'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'
+  'ZVeto_OS_Iso': 'Z Veto, OS, Isolated'
+  'ZPeak_OS_Iso': 'Z Peak, OS, Isolated'
+  'SR': 'Signal Region'
+  'SR_mbb': 'Signal Region + m_bb Cut'
+  'TT_CR': 'TT Control Region'
+  'DY_CR': 'DY Control Region'
+  'W_CR': 'W Control Region'

--- a/config/plot/Run3_2026.yaml
+++ b/config/plot/Run3_2026.yaml
@@ -1,0 +1,27 @@
+lumi_text:
+  text: "25.8 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0, -0.03 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'e': 'e'
+  'mu': '#mu'
+  'eE': 'ee'
+  'eMu': 'e #mu'
+  'muMu': '#mu #mu'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'
+  'ZVeto_OS_Iso': 'Z Veto, OS, Isolated'
+  'ZPeak_OS_Iso': 'Z Peak, OS, Isolated'
+  'SR': 'Signal Region'
+  'SR_mbb': 'Signal Region + m_bb Cut'
+  'TT_CR': 'TT Control Region'
+  'DY_CR': 'DY Control Region'
+  'W_CR': 'W Control Region'

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,5 +57,6 @@ New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/ke
 
 ## Eras
 
-HH→bb̄WW runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023` and `Run3_2023BPix`.
-See [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).
+HH→bb̄WW runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023`, `Run3_2023BPix`,
+`Run3_2024` and `Run3_2025`. 2025 reuses the 2024 Summer24 MC (with 2025 corrections);
+see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/ke
 ## Eras
 
 HH→bb̄WW runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023`, `Run3_2023BPix`,
-`Run3_2024` and `Run3_2025`. 2025 reuses the 2024 Summer24 MC (with 2025 corrections);
-see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/). 2024/2025 AK4
+`Run3_2024`, `Run3_2025` and `Run3_2026`. 2025 and 2026 reuse the 2024 Summer24 MC
+(with that year's corrections); see
+[FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/). 2024+ AK4
 b-tagging uses UParTAK4 scores and working points (ParticleNet is kept for 2022/2023).

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,4 +59,5 @@ New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/ke
 
 HH→bb̄WW runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023`, `Run3_2023BPix`,
 `Run3_2024` and `Run3_2025`. 2025 reuses the 2024 Summer24 MC (with 2025 corrections);
-see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).
+see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/). 2024/2025 AK4
+b-tagging uses UParTAK4 scores and working points (ParticleNet is kept for 2022/2023).


### PR DESCRIPTION
## Summary

HH_bbWW configs and producers for `Run3_2024` / `Run3_2025` (NanoAODv15).

- Era configs: datasets, processes, triggers, weights, plot
- CI TestModel uses the dilepton signal `GluGlutoHHto2B2Vto2L2Nu_kl_1p00_kt_1p00_c2_0p00`
- Skip missing NanoAOD jet/fatjet/subjet columns, including `FatJet_jetId` and `idbtagPNetB` in HistTuple jet selection
- 2024/2025 UParTAK4 WPs; empty `uncs_to_exclude`
- 2024/2025 btag shape disabled (`wantShape: false`) until official UParTAK4 shape files exist
- FLAF + Corrections gitlinks for the matching `prepare-run3-2025` PRs
- Docs: `docs/index.md`

Depends on the FLAF and Corrections PRs on the same branch name.

## Testing

Local `--test 1000` TestModel chain through `HistPlotTask` succeeded for `Run3_2024` and `Run3_2025`.